### PR TITLE
Feature/i18n sluggable

### DIFF
--- a/application/modules/g/views/scripts/partials/spawn/js/input-i18n-field-sets.phtml
+++ b/application/modules/g/views/scripts/partials/spawn/js/input-i18n-field-sets.phtml
@@ -1,6 +1,10 @@
 <?php
 $locales		= Garp_I18n::getLocales();
 $defaultLocale 	= Garp_I18n::getDefaultLocale();
+usort($locales, function($a, $b) use ($defaultLocale) {
+    // sort default locale on top
+    return $a === $b ? 0 : ($a === $defaultLocale ? -1 : 1);
+});
 $fieldSet		= $this->fieldSet;
 $excludedFields	= $this->spawnJs()->getExcludedFormFields();
 $relations      = $this->relations;

--- a/library/Garp/Spawn/Behavior/Type/Sluggable.php
+++ b/library/Garp/Spawn/Behavior/Type/Sluggable.php
@@ -68,9 +68,16 @@ class Garp_Spawn_Behavior_Type_Sluggable extends Garp_Spawn_Behavior_Type_Abstra
 	 * @return	Array	Configuration of the slug field
 	 */
 	protected function _getSlugFieldConfig() {
-		$slugFieldConfig 	= $this->_slugFieldConfig;
-
+		$slugFieldConfig = $this->_slugFieldConfig;
+		$model = $this->getModel();
 		if ($this->_baseFieldIsMultilingual()) {
+            if ($model instanceof Garp_Spawn_Model_I18n) {
+                // Add slug and lang as combined unique key to the model
+                // Only applicable to I18n models hence the icky instanceof check
+                $existingUnique = $model->unique ?: array();
+			    $model->unique = array_merge($existingUnique, array(array('lang', 'slug')));
+			    unset($slugFieldConfig['unique']);
+            }
 			$slugFieldConfig['multilingual'] = true;
 		}
 
@@ -136,3 +143,4 @@ class Garp_Spawn_Behavior_Type_Sluggable extends Garp_Spawn_Behavior_Type_Abstra
 	}
 
 }
+

--- a/library/Garp/Spawn/Config/Model/I18n.php
+++ b/library/Garp/Spawn/Config/Model/I18n.php
@@ -54,7 +54,7 @@ class Garp_Spawn_Config_Model_I18n extends ArrayObject {
 			$this->_extractI18nRelations($config),
 			$this->_getRelationConfigToParent()
 		);
-		$config['unique'] = $this->_getUniqueColumnNames();
+		$config['unique'] = array($this->_getUniqueColumnNames());
 		$config = $this->_correctOrderProperty($config);
 
 		return $config;

--- a/library/Garp/Spawn/Model/Base.php
+++ b/library/Garp/Spawn/Model/Base.php
@@ -13,7 +13,7 @@ class Garp_Spawn_Model_Base extends Garp_Spawn_Model_Abstract {
 
 	public function __construct(Garp_Spawn_Config_Model_Abstract $config) {
 		if ($config->isMultilingual()) {
-			$i18nModelConfig = new Garp_Spawn_Config_Model_I18n($config);
+			$i18nModelConfig = new Garp_Spawn_Config_Model_I18n(clone $config);
 			$i18nModel       = new Garp_Spawn_Model_I18n($i18nModelConfig);
 			$this->setI18nModel($i18nModel);
 		}

--- a/library/Garp/Spawn/MySql/Key/Set/Synchronizer.php
+++ b/library/Garp/Spawn/MySql/Key/Set/Synchronizer.php
@@ -223,16 +223,17 @@ class Garp_Spawn_MySql_Key_Set_Synchronizer {
 		foreach ($keysToRemove as $key) {
 			$fields = $this->_model->fields->getFields('name', $key->column);
 			$field = current($fields);
+            $columnsOutput = implode(', ', (array)$key->column);
 
 			if ($progress->isInteractive()) {
-				$progress->display("Make {$this->_model->id}.{$key->column} no longer unique? ");
+				$progress->display("Make {$this->_model->id}.{$columnsOutput} no longer unique? ");
 				if (!Garp_Spawn_Util::confirm()) {
 					continue;
 				}
 			}
 
 			if (!Garp_Spawn_MySql_UniqueKey::delete($tableName, $key)) {
-				throw new Exception("Could not set column '{$key->column}' to non-unique.");
+				throw new Exception("Could not set column '{$columnsOutput}' to non-unique.");
 			}
 		}
 	}
@@ -459,3 +460,4 @@ class Garp_Spawn_MySql_Key_Set_Synchronizer {
 		}
 	}
 }
+

--- a/library/Garp/Spawn/MySql/Table/Factory.php
+++ b/library/Garp/Spawn/MySql/Table/Factory.php
@@ -145,7 +145,12 @@ class Garp_Spawn_MySql_Table_Factory {
 		$uniqueKeys = array();
 
 		if ($unique) {
-			$uniqueKeys[] = $unique;
+			// This checks wether a single one-dimensional array is given: a collection of
+			// columns combined into a unique key, or wether an array of arrays is given, meaning
+			// multiple collections of columns combining into multiple unique keys per table.
+			$isArrayOfArrays = count(array_filter($unique, 'is_array')) === count($unique);
+			$unique = !$isArrayOfArrays ? array($unique) : $unique;
+			$uniqueKeys = array_merge($uniqueKeys, $unique);
 		}
 
 		foreach ($fields as $field) {
@@ -191,3 +196,4 @@ class Garp_Spawn_MySql_Table_Factory {
 	}
 
 }
+


### PR DESCRIPTION
# Include `lang` in unique key for i18n slugs  
This avoids having `abc` as slug in the primary language and `abc-2` in
the secondary language.   
For I18n models, the spawner includes `lang` in the unique key
constraint to make this happen.

Sluggable is also refactored to reflect this change. It will use the
given language when checking the slug's uniqueness.

Last but not least: a bug popped up after the recent Translatable
refactoring where an exception would be thrown when explicitly saving a
certain slug as opposed to auto-generating one thru the Sluggable
behavior. This feature fixes that.