### PR TITLE
Added Sentry service and implemented in Garp error hook

### DIFF
--- a/application/modules/g/controllers/ErrorController.php
+++ b/application/modules/g/controllers/ErrorController.php
@@ -18,6 +18,11 @@ class G_ErrorController extends Garp_Controller_Action {
         if (!$errors) {
             return;
         }
+
+        if (APPLICATION_ENV !== 'development') {
+            Garp_Service_Sentry::log($errors->exception);
+        }
+
         if (!$this->view) {
             $bootstrap = Zend_Registry::get('application')->getBootstrap();
             $this->view = $bootstrap->getResource('View');
@@ -90,4 +95,5 @@ class G_ErrorController extends Garp_Controller_Action {
             $this->_helper->viewRenderer('error/json', null, true);
         }
     }
+
 }

--- a/application/modules/g/controllers/ErrorController.php
+++ b/application/modules/g/controllers/ErrorController.php
@@ -19,9 +19,8 @@ class G_ErrorController extends Garp_Controller_Action {
             return;
         }
 
-        if (APPLICATION_ENV !== 'development') {
-            Garp_Service_Sentry::log($errors->exception);
-        }
+        $sentry = Garp_Service_Sentry::getInstance();
+        $sentry->log($errors->exception);
 
         if (!$this->view) {
             $bootstrap = Zend_Registry::get('application')->getBootstrap();
@@ -56,18 +55,24 @@ class G_ErrorController extends Garp_Controller_Action {
                     $this->view->lastQuery = $profiler->getLastQueryProfile()->getQuery();
                 }
             }
-        } else {
-            // Oh dear, this is the production environment. This is serious.
-            // Better log the error and mail a crash report to a nerd somewhere.
-            if ($this->getResponse()->getHttpResponseCode() != 500) {
-                return;
-            }
 
-            Garp_ErrorHandler::logErrorToFile($errors);
+            return;
+        }
 
-            if (!Garp_ErrorHandler::logErrorToSlack($errors)) {
-                Garp_ErrorHandler::mailErrorToAdmin($errors);
-            }
+        // Oh dear, this is the production environment. This is serious.
+        // Better log the error and mail a crash report to a nerd somewhere.
+        if ($this->getResponse()->getHttpResponseCode() != 500) {
+            return;
+        }
+
+        Garp_ErrorHandler::logErrorToFile($errors);
+
+        if ($sentry->isActive()) {
+            return;
+        }
+
+        if (!Garp_ErrorHandler::logErrorToSlack($errors)) {
+            Garp_ErrorHandler::mailErrorToAdmin($errors);
         }
     }
 

--- a/library/Garp/Service/Sentry.php
+++ b/library/Garp/Service/Sentry.php
@@ -1,0 +1,29 @@
+<?php
+class Garp_Service_Sentry {
+    static public function log(Exception $exception) {
+        global $ravenClient;
+
+        if (!$ravenClient) {
+            return;
+        }
+
+        $debugVars = array(
+            '_php_version' => phpversion(),
+            '_garp_version' => Garp_Version::VERSION,
+            'extensions' => get_loaded_extensions()
+        );
+
+        // Add user data to log
+        $auth = Garp_Auth::getInstance();
+        if ($auth->isLoggedIn()) {
+            $debugVars['_user_data'] = $auth->getUserData();
+        };
+
+        $extra = array('extra' => $debugVars);
+
+        $event_id = $ravenClient->getIdent(
+            $ravenClient->captureException($exception, $extra)
+        );
+    }
+        
+}


### PR DESCRIPTION
* Added a simple wrapper for Sentry, an exception monitoring service
* Added hook in Garp error controller, only firing on live sites and when `$ravenClient` is configured in `public/index.php`. This means that projects that do not have Sentry configured (yet) should not be influenced by this update.

The reason for this global configuration in `public/index.php` is that any errors should be logged in a very early stage, even before Garp has completely initialized. This should guarantee that even low level errors won't slip by unnoticed.