### PR TITLE
exclude Model classes for ValidClassName rule due to naming style

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -75,4 +75,7 @@
 <rule ref="PEAR.Commenting.ClassComment.MissingPackageTag">
     <exclude-pattern>*/tests/*</exclude-pattern>
 </rule>
+<rule ref="PEAR.NamingConventions.ValidClassName.Invalid">
+    <exclude-pattern>application/modules/default/Model/*</exclude-pattern>
+</rule>
 </ruleset>


### PR DESCRIPTION
exclude Model classes for ValidClassName rule due to naming style of relation models