### PR TITLE
Made password field plaintext by default

### DIFF
--- a/public/js/garp.passwordfieldset.js
+++ b/public/js/garp.passwordfieldset.js
@@ -50,11 +50,9 @@ Garp.PasswordFieldset = Ext.extend(Ext.form.FieldSet, {
 		var scope = this;
 		this._interval = setInterval(function(){
 			if (scope.password) {
-				if (scope.password.isVisible() ) {
-					if (scope.password.isVisible() && scope.password.isDirty()) {
-						scope.callback(scope.password, scope.password.getValue());
-						scope.password.originalValue = scope.password.getValue();
-					}
+				if (scope.password.isVisible() && scope.password.isDirty()) {
+					scope.callback(scope.password, scope.password.getValue());
+					scope.password.originalValue = scope.password.getValue();
 				}
 			} else {
 				clearInterval(this._interval);

--- a/public/js/garp.passwordfieldset.js
+++ b/public/js/garp.passwordfieldset.js
@@ -15,13 +15,9 @@ Garp.PasswordFieldset = Ext.extend(Ext.form.FieldSet, {
 	},
 
 	collapseAndHide: function(){
-		this.showpassword.hide();
 		this.password.hide();
-		this.plaintext.hide();
 		this.password.setValue('');
 		this.password.originalValue = '';
-		this.plaintext.setValue('');
-		this.plaintext.originalValue = '';
 	},
 
 	initComponent: function(ct){
@@ -34,12 +30,10 @@ Garp.PasswordFieldset = Ext.extend(Ext.form.FieldSet, {
 			boxMaxWidth: 64,
 			handler: function(){
 				var r = this.refOwner;
-				if (r.showpassword.isVisible()) {
+				if (r.password.isVisible()) {
 					r.collapseAndHide();
 				} else {
-					r.showpassword.show();
 					r.password.show();
-					r.plaintext.hide();
 					r.password.focus(20);
 				}
 			}
@@ -49,53 +43,17 @@ Garp.PasswordFieldset = Ext.extend(Ext.form.FieldSet, {
 			inputType: 'text',
 			hidden: true,
 			listeners: {
-				/**
-				 * This render callback tricks Google Chrome. It normally tries to auto-populate
-				 * forms with a password field. In our case it fails horribly and clears the form,
-				 * leaving the administrator with blank fields.
-				 * This callback swaps the "text" type for an actual "password" type. Chrome will
-				 * leave the form alone thinking it does not contain a password field.
-				 */
-				'render': function() {
-					var dom = this.el.dom;
-					setTimeout(function() {
-						dom.setAttribute('type', 'password');
-					}, 100);
-				},
 				'change': this.callback
-			}
-		}, {
-			ref: 'plaintext',
-			fieldLabel : __('Password'),
-			inputType: 'text',
-			hidden: true,
-			listeners: {
-				'change': this.callback
-			}
-		}, {
-			ref: 'showpassword',
-			fieldLabel: __('Show Password'),
-			xtype: 'checkbox',
-			allowBlank: true,
-			hidden: true,
-			handler: function(){
-				var r = this.refOwner, c = this.checked;
-				r.password.setVisible(!c);
-				r.plaintext.setVisible(c);
-				r[c ? 'plaintext' : 'password'].setValue(r[c ? 'password' : 'plaintext'].getValue());
 			}
 		}];
 
 		var scope = this;
 		this._interval = setInterval(function(){
 			if (scope.password) {
-				if (scope.password.isVisible() || scope.plaintext.isVisible()) {
+				if (scope.password.isVisible() ) {
 					if (scope.password.isVisible() && scope.password.isDirty()) {
 						scope.callback(scope.password, scope.password.getValue());
 						scope.password.originalValue = scope.password.getValue();
-					} else if (scope.plaintext.isDirty()) {
-						scope.callback(scope.plaintext, scope.plaintext.getValue());
-						scope.plaintext.originalValue = scope.plaintext.getValue();
 					}
 				}
 			} else {
@@ -104,7 +62,6 @@ Garp.PasswordFieldset = Ext.extend(Ext.form.FieldSet, {
 		}, 100);
 
 		Garp.PasswordFieldset.superclass.initComponent.call(this, ct);
-
 
 	}
 


### PR DESCRIPTION
Chrome 53 (might've been earlier) prevents loading of any data in the User model view when there's a stored password for the current website/admin. What I've done:

- Changed password input type to text, so effectively making the password plaintext by default. WordPress for example does this for a while now; there is no option to 'hide' your password from the screen while changing it, making any confirmation unnecessary (we didn't have that anyway).
- Removed the `plaintext` and `showpassword` field/button, since the default password is already plaintext.
- It's still accessible as a 'password', since the label says so.

PS: I think obfuscating your password while changing it is less important than showing your password while changing it (without any confirmation). Also a working CMS is pretty important. We've tried to fix this several times now (by switching input types or rendering fake name/password fields first). These methods fail every time after Chrome updates though.