### PR TITLE
Send a Slack notification after deploy

### DIFF
--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -47,6 +47,7 @@ namespace :deploy do
 
 	task :finished do
 		invoke :disable_under_construction
+		invoke :notify_slack
 	end
 end
 

--- a/deploy/tasks/garp.cap
+++ b/deploy/tasks/garp.cap
@@ -18,6 +18,13 @@ task :disable_under_construction do
 	end
 end
 
+desc "Notify Slack"
+task :notify_slack do
+    on roles(:app) do
+        execute "php #{release_path}/vendor/grrr-amsterdam/garp3/scripts/garp.php Slack sendDeployNotification --branch=#{fetch(:branch)} --user=#{fetch(:local_user)} --e=#{fetch(:stage)}"
+    end
+end
+
 desc "Spawn models"
 task :spawn do
 	# Since there is often a shared database server for multiple web servers,


### PR DESCRIPTION
Sends a Slack notification after deploy.

See channel `#harmens_test` for an example message.
