### PR TITLE
re-added correct Content-Type

### DIFF
--- a/application/modules/g/controllers/ExtController.php
+++ b/application/modules/g/controllers/ExtController.php
@@ -346,7 +346,7 @@ class G_ExtController extends G_ContentController {
     }
 
     protected function _renderJs() {
-        // $this->getResponse()->setHeader('Content-Type', 'text/javascript; charset=UTF-8');
+        $this->getResponse()->setHeader('Content-Type', 'text/javascript; charset=UTF-8');
         $this->_helper->layout->setLayout('json');
     }
 }


### PR DESCRIPTION
Why is this commented-out? It prevents support for the "[X-Content-Type-Options: nosniff](https://blog.mozilla.org/security/2016/08/26/mitigating-mime-confusion-attacks-in-firefox/)" header.