### PR TITLE
Auto deploy

### DIFF
--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -12,7 +12,9 @@ namespace :deploy do
         end
 
         invoke :verify_production_deploy
-        #invoke :check_grunt_status
+        invoke :build_assets
+        invoke :distribute_assets
+
         invoke :enable_under_construction
     end
 
@@ -27,7 +29,7 @@ namespace :deploy do
         invoke :garp_env_setup
 
         # Assets
-        invoke :build_and_push_assets
+        invoke :push_assets
 
         # Auth tasks
         invoke :set_webroot_permissions
@@ -50,7 +52,6 @@ namespace :deploy do
 
     task :finished do
         invoke :disable_under_construction
-        invoke :distribute_assets
         invoke :notify_slack
     end
 end

--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -26,6 +26,9 @@ namespace :deploy do
 		invoke :spawn
 		invoke :garp_env_setup
 
+        # Assets
+        invoke :build_and_push_assets
+
 		# Auth tasks
 		invoke :set_webroot_permissions
 	end
@@ -47,6 +50,7 @@ namespace :deploy do
 
 	task :finished do
 		invoke :disable_under_construction
+        invoke :distribute_assets
 		invoke :notify_slack
 	end
 end

--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -1,60 +1,60 @@
 namespace :deploy do
 
-	task :failed do
-		invoke :disable_under_construction
-	end
+    task :failed do
+        invoke :disable_under_construction
+    end
 
-	task :started do
-		on roles(:web) do
-			# Grab last release directory, if any
-			releases = capture("ls #{File.join(fetch(:deploy_to), 'releases')}")
-			set :this_host_last_release, releases.split("\n").sort.last
-		end
+    task :started do
+        on roles(:web) do
+            # Grab last release directory, if any
+            releases = capture("ls #{File.join(fetch(:deploy_to), 'releases')}")
+            set :this_host_last_release, releases.split("\n").sort.last
+        end
 
-		invoke :verify_production_deploy
-		#invoke :check_grunt_status
-		invoke :enable_under_construction
-	end
+        invoke :verify_production_deploy
+        #invoke :check_grunt_status
+        invoke :enable_under_construction
+    end
 
-	task :updated do
-		# Disk tasks
-		invoke :create_system_cache_dirs
-		invoke :create_static_cache_dir
+    task :updated do
+        # Disk tasks
+        invoke :create_system_cache_dirs
+        invoke :create_static_cache_dir
 
-		# Garp tasks
-		invoke :composer_install
-		invoke :spawn
-		invoke :garp_env_setup
+        # Garp tasks
+        invoke :composer_install
+        invoke :spawn
+        invoke :garp_env_setup
 
         # Assets
         invoke :build_and_push_assets
 
-		# Auth tasks
-		invoke :set_webroot_permissions
-	end
+        # Auth tasks
+        invoke :set_webroot_permissions
+    end
 
-	task :published do
-		#invoke :update_cluster_servers
-	end
+    task :published do
+        #invoke :update_cluster_servers
+    end
 
-	task :setup do
-		invoke :validate_app_name
-		invoke :add_public_ssh_keys
-		invoke :find_webroot
-		invoke :mark_git_server_safe
-		invoke :create_deploy_dirs
-		invoke :set_shared_dirs_permissions
-		invoke :create_webroot_reroute_htaccess
-		invoke :install_crontab
-	end
+    task :setup do
+        invoke :validate_app_name
+        invoke :add_public_ssh_keys
+        invoke :find_webroot
+        invoke :mark_git_server_safe
+        invoke :create_deploy_dirs
+        invoke :set_shared_dirs_permissions
+        invoke :create_webroot_reroute_htaccess
+        invoke :install_crontab
+    end
 
-	task :finished do
-		invoke :disable_under_construction
+    task :finished do
+        invoke :disable_under_construction
         invoke :distribute_assets
-		invoke :notify_slack
-	end
+        invoke :notify_slack
+    end
 end
 
 task :check do
-	invoke :check_ssh_forwarding
+    invoke :check_ssh_forwarding
 end

--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -20,44 +20,44 @@ task :distribute_assets do
 end
 
 desc "Check if a grunt build is necessary"
-task :check_grunt_status do 
-	run_locally do
-		has_grunt = capture('[ -e "Gruntfile.js" ] && echo 1 || echo 0').strip == '1'
-		if has_grunt
-			env = fetch(:stage)
-			start_branch = get_current_git_branch self
-			deploy_branch = fetch(:branch)
+task :check_grunt_status do
+    run_locally do
+        has_grunt = capture('[ -e "Gruntfile.js" ] && echo 1 || echo 0').strip == '1'
+        if has_grunt
+            env = fetch(:stage)
+            start_branch = get_current_git_branch self
+            deploy_branch = fetch(:branch)
 
-			if !is_git_status_clean self
-				error "Your Git status is not clean.\nPlease commit "\
-					"everything before deploying this Grunt-enabled project."
-				exit
-			end
+            if !is_git_status_clean self
+                error "Your Git status is not clean.\nPlease commit "\
+                    "everything before deploying this Grunt-enabled project."
+                exit
+            end
 
-			warn "WARNING! Switching to Git branch [#{deploy_branch}]"
-			switch_git_branch self, deploy_branch
+            warn "WARNING! Switching to Git branch [#{deploy_branch}]"
+            switch_git_branch self, deploy_branch
 
-			execute "grunt #{env}"
-			
-			if !is_git_status_clean self
-				error "Your compiled assets are not up-to-date.\n"/
-					"Please commit the Grunt output and try deploying again."
-				exit
-			end
+            execute "grunt #{env}"
 
-			switch_git_branch self, start_branch
-		end
-	end
+            if !is_git_status_clean self
+                error "Your compiled assets are not up-to-date.\n"/
+                    "Please commit the Grunt output and try deploying again."
+                exit
+            end
+
+            switch_git_branch self, start_branch
+        end
+    end
 end
 
 def is_git_status_clean cap
-	cap.capture('[ "`git status --porcelain | grep -c \'^.[M?]\'`" -eq "0" ] || echo 0').strip != '0'
+    cap.capture('[ "`git status --porcelain | grep -c \'^.[M?]\'`" -eq "0" ] || echo 0').strip != '0'
 end
 
 def get_current_git_branch cap
-	cap.capture('git rev-parse --abbrev-ref HEAD')
+    cap.capture('git rev-parse --abbrev-ref HEAD')
 end
 
 def switch_git_branch cap, branch
-	cap.execute "git checkout #{branch}"
+    cap.execute "git checkout #{branch}"
 end

--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -1,9 +1,15 @@
+desc "Build assets"
+task :build_assets do
+    run_locally do
+        env = fetch(:stage)
+        execute "gulp --e=#{env}"
+    end
+end
+
 desc "Push built assets to the webserver"
-task :build_and_push_assets do
+task :push_assets do
     on roles(:web) do |host|
         run_locally do
-            env = fetch(:stage)
-            execute "gulp --e=#{env}"
             execute "scp rev-manifest-*.json #{host.user}@#{host.hostname}:#{release_path}"
             execute "scp -r public/css/build/* #{host.user}@#{host.hostname}:#{release_path}"\
                 "/public/css/build/"

--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -1,3 +1,24 @@
+desc "Push built assets to the webserver"
+task :build_and_push_assets do
+    on roles(:web) do |host|
+        run_locally do
+            env = fetch(:stage)
+            execute "gulp --e=#{env}"
+            execute "scp rev-manifest-*.json #{host.user}@#{host.hostname}:#{release_path}"
+            execute "scp -r public/css/build/* #{host.user}@#{host.hostname}:#{release_path}"\
+                "/public/css/build/"
+        end
+    end
+end
+
+desc "Distributing assets to CDN"
+task :distribute_assets do
+    run_locally do
+        env = fetch(:stage)
+        execute "vendor/bin/g cdn distribute --to=#{env} --since=forever"
+    end
+end
+
 desc "Check if a grunt build is necessary"
 task :check_grunt_status do 
 	run_locally do


### PR DESCRIPTION
* Now gulping from within Capistrano process
* Copying `rev-manifest` json files from local to webserver
* Copying built css assets from local to webserver
* Distributing assets from within Capistrano process

I have moved the frontend build process and the distribution of assets to the Capistrano deploy process. This way, all that the new root `deploy.sh` file has to do is install dependencies, and then call on Capistrano. The building and distribution process are also tied together more to the deploy process in this fashion, as I think they should be.

If we implement this into the main branch, we can take the `rev-manifest` and the built css folder out of Git. We should also implement a `Gemfile` for existing dependencies which have so far been undefined. I am working on that in our test case project for auto-deployment.

We do really need to do something about the size of the existing Garp assets. 
`g cdn distribute --since=forever` indeed does take forever, and I think that is unnecessary. 
@harmenjanssen you were going to dive into that, right?
I am now waiting for the Slack deploy message until we distribute everything. I don't wait for it with taking down the construction notice.

(PS: OCD alert - sorry for the spacing. If I would convert tabs to spaces for the whole doc, you wouldn't be able to see what's changed 🤓)