### PR TITLE
Simplified display of CDN Distribute

### DIFF
--- a/library/Garp/Content/Cdn/Distributor.php
+++ b/library/Garp/Content/Cdn/Distributor.php
@@ -32,6 +32,7 @@ class Garp_Content_Cdn_Distributor {
 
     /**
      * Returns the list of available environments.
+     * 
      * @return Array The list of environments.
      */
     public function getEnvironments() {

--- a/library/Garp/Content/Cdn/Distributor.php
+++ b/library/Garp/Content/Cdn/Distributor.php
@@ -68,12 +68,6 @@ class Garp_Content_Cdn_Distributor {
         }
 
         Garp_Cli::lineOut(ucfirst($env));
-        $progressBar = Garp_Cli_Ui_ProgressBar::getInstance();
-        $progressBar->init($assetCount);
-        $firstFilename = basename($assetList[0]);
-        $fileOrFiles = $this->_printFileOrFiles($assetCount);
-        $progressBar->display("Processing {$firstFilename}. {$assetCount} {$fileOrFiles} left.");
-
         $s3 = new Garp_File_Storage_S3($ini->cdn, dirname(current($assetList)), true);
 
         foreach ($assetList as $i => $asset) {
@@ -81,17 +75,13 @@ class Garp_Content_Cdn_Distributor {
             $fileData = file_get_contents($this->_baseDir . $asset);
             $filename = basename($asset);
             if ($s3->store($filename, $fileData, true, false)) {
-                $progressBar->advance();
-                $fileOrFiles = $this->_printFileOrFiles($assetCount - $progressBar->getProgress());
-                $progressBar->display("Processing {$filename}. %d {$fileOrFiles} left.");
-            } else {
-                $progressBar->displayError("Could not upload {$asset} to {$env}.");
+                echo '.';
+            } else { 
+                Garp_Cli::errorOut("\nCould not upload {$asset} to {$env}.");
             }
         }
 
-        if ($progressBar->getProgress() === $assetCount) {
-            $progressBar->display("√ Done");
-        }
+        Garp_Cli::lineOut("\n√ Done");
 
         echo "\n\n";
     }

--- a/library/Garp/Content/Cdn/Distributor.php
+++ b/library/Garp/Content/Cdn/Distributor.php
@@ -1,18 +1,20 @@
 <?php
 /**
  * Garp_Content_Cdn_Distributor
- * @author David Spreekmeester | grrr.nl
- * @modifiedby $LastChangedBy: $
- * @version $Revision: $
+ *
  * @package Garp
  * @subpackage Content
+ * @author David Spreekmeester | grrr.nl
+ * @version $Revision: $
+ * @modifiedby $LastChangedBy: $
  * @lastmodified $Date: $
  */
 class Garp_Content_Cdn_Distributor {
     protected $_environments = array('development', 'integration', 'staging', 'production');
 
     /**
-     * Where the baseDir for assets is located, relative to APPLICATION_PATH. Without trailing slash.
+     * Where the baseDir for assets is located, relative to APPLICATION_PATH.
+     * Without trailing slash.
      */
     const RELATIVE_BASEDIR_AFTER_APPLICATION_PATH = '/../public';
 

--- a/library/Garp/Content/Cdn/Distributor.php
+++ b/library/Garp/Content/Cdn/Distributor.php
@@ -4,7 +4,7 @@
  *
  * @package Garp
  * @subpackage Content
- * @author David Spreekmeester | grrr.nl
+ * @author David Spreekmeester <david@grrr.nl>
  * @version $Revision: $
  * @modifiedby $LastChangedBy: $
  * @lastmodified $Date: $
@@ -24,12 +24,15 @@ class Garp_Content_Cdn_Distributor {
     protected $_baseDir;
 
     public function __construct($path = null) {
-        $this->_baseDir = realpath($path ?:
-            APPLICATION_PATH . self::RELATIVE_BASEDIR_AFTER_APPLICATION_PATH);
+        $this->_baseDir = realpath(
+            $path ?:
+            APPLICATION_PATH . self::RELATIVE_BASEDIR_AFTER_APPLICATION_PATH
+        );
     }
 
     /**
      * Returns the list of available environments.
+     * @return Array The list of environments.
      */
     public function getEnvironments() {
         return $this->_environments;
@@ -44,6 +47,7 @@ class Garp_Content_Cdn_Distributor {
 
     /**
      * Select assets to be distributed.
+     *
      * @param   String  $filterString
      * @param   Mixed   $filterDate     Provide null for default date filter,
      *                                  false to disable filter, or a strtotime compatible
@@ -55,7 +59,10 @@ class Garp_Content_Cdn_Distributor {
     }
 
     /**
-     * @param String $env Name of the environment, f.i. 'development' or 'production'.
+     * @param String    $env        Name of the environment, f.i. 'development' or 'production'.
+     * @param Array     $assetList  List of asset file paths
+     * @param Int       $assetCount Number of assets
+     * @return Void
      */
     public function distribute($env, $assetList, $assetCount) {
         $this->_validateEnvironment($env);
@@ -90,7 +97,10 @@ class Garp_Content_Cdn_Distributor {
 
     protected function _validateEnvironment($env) {
         if (!in_array($env, $this->_environments)) {
-            throw new Exception("'{$env}' is not a valid environment. Try: " . implode(', ', $this->_environments));
+            throw new Exception(
+                "'{$env}' is not a valid environment. Try: "
+                . implode(', ', $this->_environments)
+            );
         }
     }
 


### PR DESCRIPTION
So that it's more suitable for batch processing and auto-deploy.

I took out the (broken) implementation of the Garp progress bar.
It's not suitable for machine processing, Travis hangs on it when trying to distribute the assets.

I replaced it by a dot line indicator. Takes a bit more space and gives less intuitive feedback on the process, but at least you can clearly see if the process is still running.