### PR TITLE
Fixed 777 permissions

### DIFF
--- a/deploy/tasks/auth.cap
+++ b/deploy/tasks/auth.cap
@@ -42,7 +42,7 @@ end
 desc "Set permissions on release path cache directory"
 task :set_release_path_cache_dir_permissions do
     on roles(:web) do
-        execute "chmod -R 777 #{release_path}/public/cached"
-        execute "chmod -R 777 #{release_path}/application/data/cache"
+        execute "chmod -R g+w,o+rx #{release_path}/public/cached"
+        execute "chmod -R g+w,o+rx #{release_path}/application/data/cache"
     end
 end


### PR DESCRIPTION
Please, NEVER, NEVER use 777.
Only owner + group are allowed to have write permissions.
(Next to the fact that 777 is just an oldschool 'hackish' way of spelling out the permissions)