### PR TITLE
Read Sentry API URL from .env before constant

### DIFF
--- a/application/init.php
+++ b/application/init.php
@@ -21,19 +21,20 @@ if (!defined('BASE_PATH')) {
 define('APPLICATION_PATH', BASE_PATH . '/application');
 define('GARP_APPLICATION_PATH', realpath(dirname(__FILE__)));
 
+if (file_exists(APPLICATION_PATH . '/../.env')) {
+    $dotenv = new Dotenv\Dotenv(APPLICATION_PATH . '/..');
+    $dotenv->load();
+}
+
 // Sentry integration
-if (defined('SENTRY_API_URL') && APPLICATION_ENV !== 'development') {
-    $ravenClient = new Raven_Client(SENTRY_API_URL);
+if (getenv('SENTRY_API_URL') || (defined('SENTRY_API_URL') && APPLICATION_ENV !== 'development')) {
+    $sentryApiUrl = getenv('SENTRY_API_URL') ?: SENTRY_API_URL;
+    $ravenClient = new Raven_Client($sentryApiUrl);
     $ravenErrorHandler = new Raven_ErrorHandler($ravenClient);
     $ravenErrorHandler->registerExceptionHandler();
     $ravenErrorHandler->registerErrorHandler();
     $ravenErrorHandler->registerShutdownFunction();
     Zend_Registry::set('RavenClient', $ravenClient);
-}
-
-if (file_exists(APPLICATION_PATH . '/../.env')) {
-    $dotenv = new Dotenv\Dotenv(APPLICATION_PATH . '/..');
-    $dotenv->load();
 }
 
 $appSpecificInit = APPLICATION_PATH . '/configs/init.php';


### PR DESCRIPTION
Right now, `index.php` is the sole entrypoint which configures Sentry,
but it's not the only entrypoint of a Garp application.
CLI commands actually use `garp/scripts/garp.php`. Both of these use
`init.php` to configure a bunch of stuff, so that should be the place
where things like Sentry are configured.

Thus: this refactors `init.php` so that it tries to get Sentry's API
URL first from `getenv()`, allowing users to maintain Sentry's API URL
from a `.env` file.
To maintain backward compatibility it will still check for the existence
of the constant as before.