### PR TITLE
Feature/david disk permission improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
     - '5.3'
+sudo: false
 script:
     - composer test
     - if [ "$(git diff --diff-filter=ACMR --name-only HEAD^..HEAD -- '*.php')" != "" ]; then ./vendor/bin/phpcs --standard=phpcs.xml --colors --encoding=utf-8 -n -p $(git diff --diff-filter=ACMR --name-only HEAD^..HEAD -- '*.php'); fi

--- a/application/configs/deploy.rb
+++ b/application/configs/deploy.rb
@@ -5,6 +5,7 @@ set :linked_dirs, %w{
 	application/data/logs
 	application/data/cache/tags
     application/data/cache/htmlpurifier
+    public/cached
 }
 set :keep_releases, 2
 

--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -12,6 +12,8 @@ namespace :deploy do
         end
 
         invoke :verify_production_deploy
+        invoke :create_deploy_dirs
+        invoke :set_shared_dir_permissions
         invoke :build_assets
         invoke :distribute_assets
 
@@ -19,10 +21,6 @@ namespace :deploy do
     end
 
     task :updated do
-        # Disk tasks
-        invoke :create_system_cache_dirs
-        invoke :create_static_cache_dir
-
         # Garp tasks
         invoke :composer_install
         invoke :spawn
@@ -33,7 +31,6 @@ namespace :deploy do
 
         # Auth tasks
         invoke :set_webroot_permissions
-        invoke :set_release_path_cache_dir_permissions
     end
 
     task :published do
@@ -46,7 +43,7 @@ namespace :deploy do
         invoke :find_webroot
         invoke :mark_git_server_safe
         invoke :create_deploy_dirs
-        invoke :set_shared_dirs_permissions
+        invoke :set_shared_dir_permissions
         invoke :create_webroot_reroute_htaccess
         invoke :install_crontab
     end

--- a/deploy/tasks/auth.cap
+++ b/deploy/tasks/auth.cap
@@ -29,20 +29,13 @@ task :mark_git_server_safe do
 end
 
 desc "Set permissions on essential deploy directories"
-task :set_shared_dirs_permissions do
+task :set_shared_dir_permissions do
 	on roles(:web) do
     	execute "chmod -R g+w #{deploy_to}/shared/backup/db"
     	execute "chmod -R g+w,o+rx #{deploy_to}/shared/public/uploads/documents"
     	execute "chmod -R g+w,o+rx #{deploy_to}/shared/public/uploads/images"
     	execute "chmod -R g+w,o+rx #{deploy_to}/shared/application/data/logs"
         execute "chmod -R g+w,o+rx #{deploy_to}/shared/application/data/cache"
+        execute "chmod -R g+w,o+rx #{deploy_to}/shared/public/cached"
 	end
-end
-
-desc "Set permissions on release path cache directory"
-task :set_release_path_cache_dir_permissions do
-    on roles(:web) do
-        execute "chmod -R g+w,o+rx #{release_path}/public/cached"
-        execute "chmod -R g+w,o+rx #{release_path}/application/data/cache"
-    end
 end

--- a/deploy/tasks/disk.cap
+++ b/deploy/tasks/disk.cap
@@ -1,34 +1,16 @@
-desc "Create backend cache directories"
-task :create_system_cache_dirs do
-	on roles(:web) do
-    	server_cache_dir = "#{deploy_to}/shared/application/data/cache"
-
-    	execute print_create_dir_if_nonexistent "#{server_cache_dir}"
-    	execute print_create_dir_if_nonexistent "#{server_cache_dir}/htmlpurifier"
-    	execute print_create_dir_if_nonexistent "#{server_cache_dir}/htmlpurifier/URI"
-    	execute print_create_dir_if_nonexistent "#{server_cache_dir}/htmlpurifier/HTML"
-    	execute print_create_dir_if_nonexistent "#{server_cache_dir}/htmlpurifier/CSS"
-    	# run "echo '<?php' > #{server_cache_dir}/pluginLoaderCache.php"
-    end
-end
-
-desc "Create static html cache directory"
-task :create_static_cache_dir do
-	on roles(:web) do
-		static_cache_dir = "#{deploy_to}/shared/public/cached";
-    	execute print_create_dir_if_nonexistent static_cache_dir
-	end
-end
-
 desc "Create essential deploy directories"
 task :create_deploy_dirs do
 	on roles(:web) do
-    	execute print_create_dir_if_nonexistent "#{deploy_to}/releases"
-    	execute print_create_dir_if_nonexistent "#{deploy_to}/shared/backup/db"
-    	execute print_create_dir_if_nonexistent "#{deploy_to}/shared/public/uploads/documents"
-    	execute print_create_dir_if_nonexistent "#{deploy_to}/shared/public/uploads/images"
-    	execute print_create_dir_if_nonexistent "#{deploy_to}/shared/application/data/logs"
-    	execute print_create_dir_if_nonexistent "#{deploy_to}/shared/application/data/cache/tags"
+    	execute print_create_dir "#{deploy_to}/releases"
+    	execute print_create_dir "#{deploy_to}/shared/backup/db"
+    	execute print_create_dir "#{deploy_to}/shared/public/uploads/documents"
+    	execute print_create_dir "#{deploy_to}/shared/public/uploads/images"
+    	execute print_create_dir "#{deploy_to}/shared/application/data/logs"
+    	execute print_create_dir "#{deploy_to}/shared/application/data/cache/tags"
+    	execute print_create_dir "#{deploy_to}/shared/application/data/cache/htmlpurifier/URI"
+    	execute print_create_dir "#{deploy_to}/shared/application/data/cache/htmlpurifier/HTML"
+    	execute print_create_dir "#{deploy_to}/shared/application/data/cache/htmlpurifier/CSS"
+    	execute print_create_dir "#{deploy_to}/shared/public/cached"
     end
 end
 
@@ -46,6 +28,6 @@ task :validate_app_name do
 	end
 end
 
-def print_create_dir_if_nonexistent dir
+def print_create_dir dir
 	"[ ! -d '#{dir}' ] && mkdir -p #{dir} || echo 0";
 end

--- a/deploy/tasks/disk.cap
+++ b/deploy/tasks/disk.cap
@@ -1,8 +1,7 @@
 desc "Create backend cache directories"
 task :create_system_cache_dirs do
 	on roles(:web) do
-		path = "#{releases_path}/#{release_timestamp}"
-    	server_cache_dir = "#{path}/application/data/cache"
+    	server_cache_dir = "#{deploy_to}/shared/application/data/cache"
 
     	execute print_create_dir_if_nonexistent "#{server_cache_dir}"
     	execute print_create_dir_if_nonexistent "#{server_cache_dir}/htmlpurifier"
@@ -16,7 +15,7 @@ end
 desc "Create static html cache directory"
 task :create_static_cache_dir do
 	on roles(:web) do
-		static_cache_dir = "#{release_path}/public/cached";
+		static_cache_dir = "#{deploy_to}/shared/public/cached";
     	execute print_create_dir_if_nonexistent static_cache_dir
 	end
 end


### PR DESCRIPTION
This basically simplifies the setup of writable dirs, ensuring those can only have their origin in the `shared` folder.

This way it's easier to manage the permissions per project. Fixing some currently permission-troubled projects might require a one-time app-specific `chgrp` / `chown`, because the user / group setup can be different per project. This is also why we can't do that universally in f.i. `deploy:setup`.