### PR TITLE
Improve deploy downtime

### DIFF
--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -15,19 +15,24 @@ namespace :deploy do
         invoke :create_deploy_dirs
         invoke :set_shared_dir_permissions
         invoke :build_assets
-        invoke :distribute_assets
-
-        invoke :enable_under_construction
     end
 
     task :updated do
-        # Garp tasks
+        # Composer
         invoke :composer_install
-        invoke :spawn
-        invoke :garp_env_setup
 
         # Assets
         invoke :push_assets
+        invoke :distribute_assets
+
+        # Set under construction
+        invoke :enable_under_construction
+    end
+
+    after :updated, :after_updated do
+        # Garp tasks
+        invoke :spawn
+        invoke :garp_env_setup
 
         # Auth tasks
         invoke :set_webroot_permissions


### PR DESCRIPTION
- Split up `updated` task in a regular and after hook
- The `enable_under_construction` task is only invoked before running the spawn task, since `composer_install` and `push_assets` can take a long time, and have nothing to do with preventing database CRUD operations, and therefore limiting website downtime
---
In practice websites can be unreachable for up to 2 minutes when deploying, depending on the time a Composer install (updated dependencies, network conditions) and the scp'ing of assets takes. 

Now we invoke all those tasks before, since they're unrelated to preventing 'damage' due to code/database changes. The `enable_under_construction` is only invoked just before spawning, when everything is in place to start the actual spawning. This should result in a downtime of about 10 seconds, instead of (sometimes) several minutes due to installing Composer dependencies and pushing assets in the meantime.