### PR TITLE
added a better e-mail validator to ExtJs

### DIFF
--- a/application/modules/g/views/helpers/SpawnJs.php
+++ b/application/modules/g/views/helpers/SpawnJs.php
@@ -72,7 +72,7 @@ class G_View_Helper_SpawnJs extends Zend_View_Helper_Abstract {
     public function getFieldValidationType(Garp_Spawn_Field $field) {
         switch ($field->type) {
         case 'email':
-            return 'email';
+            return 'garpEmail';
             break;
         case 'url':
             return 'mailtoOrUrl';

--- a/public/js/overrides.js
+++ b/public/js/overrides.js
@@ -32,6 +32,17 @@ Ext.override(Ext.Element, {
 	});
 })();
 
+(function(){
+    // @see: http://emailregex.com/
+    var emailRegEx = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    Ext.apply(Ext.form.VTypes, {
+        garpEmail: function(val, field) {
+            return emailRegEx.test(val);
+        },
+        garpEmailText: 'Not a valid email'
+    });
+})();
+
 Garp.mailtoOrUrlPlugin = {
 	init: function(field){
 		var stricter = /(^mailto:(\w+)([\-+.][\w]+)*@(\w[\-\w]*))|(((^https?)|(^ftp)):\/\/([\-\w]+\.)+\w{2,3}(\/[%\-\w]+(\.\w{2,})?)*(([\w\-\.\?\\\/+@&#;`~=%!]*)(\.\w{2,})?)*\/?)/i;


### PR DESCRIPTION
The ExtJS email validator for `vtype: email` won't allow long TLDs (like ramiro@sou.amsterdam).

This will add a custom vtype with a better regular expression for validating emailaddresses.