### PR TITLE
Added Capistrano since argument for CDN distribution

### DIFF
--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -36,7 +36,8 @@ desc "Distributing assets to CDN"
 task :distribute_assets do
     run_locally do
         env = fetch(:stage)
-        execute "[ ! \"$(vendor/bin/g config get cdn.readonly)\" ]; vendor/bin/g cdn distribute --to=#{env} --since=forever"
+        since_argument = ENV['distribute_since'] ? "--since=#{ENV['distribute_since']}" : ''
+        execute "[ ! \"$(vendor/bin/g config get cdn.readonly)\" ]; vendor/bin/g cdn distribute --to=#{env} #{since_argument}"
     end
 end
 


### PR DESCRIPTION
Distributes to CDN without argument by default, only if you want to deploy with a full distribution the user has to specify a specific `since`, like so:

```
cap staging deploy since=forever
```

This will make deployments a LOT faster, and developers Happy™.

Of course the `since` argument is tied to `g cdn distribute`, so the argument could be renamed to something CDN-global-specific, although this is one seemed most familiar.