### PR TITLE
Added BASE_PATH specifically for Garp unit test context

### DIFF
--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -10,6 +10,7 @@ ini_set('log_errors', 0);
 ini_set('display_startup_errors', 1);
 ini_set('display_errors', 'stderr');
 
+define('BASE_PATH', $garpRoot);
 require_once $garpRoot . '/application/init.php';
 
 // Grab either the configuration of a host project, where garp3 is installed as dependency,


### PR DESCRIPTION
The `BASE_PATH` was pointing to a level higher than it should from a Garp unit test context.