### PR TITLE
Fix actually waiting for STDIN when prompting

### DIFF
--- a/scripts/garp.php
+++ b/scripts/garp.php
@@ -120,6 +120,7 @@ if (empty($args[0])) {
  */
 stream_set_blocking(STDIN, false);
 $stdin = trim(stream_get_contents(STDIN));
+stream_set_blocking(STDIN, true);
 
 /* Construct command classname */
 $classArgument = ucfirst($args[0]);


### PR DESCRIPTION
Oops. Blocking was removed for grabbing data piped into scripts/garp.php.
It shouldn't have been removed for regular prompts for STDIN.

This simple fix makes sure everything is back to normal.