### PR TITLE
Configure curl not to auto-print its output

### DIFF
--- a/library/Garp/Cache/Manager.php
+++ b/library/Garp/Cache/Manager.php
@@ -203,6 +203,7 @@ class Garp_Cache_Manager {
         curl_setopt(
             $ch, CURLOPT_HTTPHEADER, array('Host: ' . $hostName)
         );
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 
         curl_exec($ch);
         curl_close($ch);


### PR DESCRIPTION
@HammenWS Not sure if you're familiar with this option, but it's almost always what you want when using curl. 🙂 
When omitted, curl just prints the output of the HTTP command into whatever process it's currently executed from.