### PR TITLE
Added Yarn install before building frontend assets

### DIFF
--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -2,12 +2,7 @@ desc "Build assets"
 task :build_assets do
     run_locally do
         env = fetch(:stage)
-        has_grunt = capture('[ -e "Gruntfile.js" ] && echo 1 || echo 0').strip == '1'
-        if has_grunt
-            execute "grunt #{env}"
-        else
-            execute "gulp --e=#{env}"
-        end
+            execute "yarn && gulp --e=#{env}"
     end
 end
 


### PR DESCRIPTION
Should only add less than a second extra to a deploy when all assets are properly installed on the deployers machine, but will prevent a lot of broken environments (which happened quite often lately).

---

- Will prevent building assets with missing packages
- Removed obsolete Grunt check