### PR TITLE
Cdn distribute warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ function afterFetch($args) {
 ```
 If your app uses `Zend_Registry::get('CMS')` it will need to refactor that bit.
 
+### Version 3.11.19
+
+Since credentials for CDNs moved to `.env` files, `g cdn distribute` is no longer able to distribute to the right environment, since the credentials are not known across envs anymore.
+[12g](https://github.com/grrr-amsterdam/12g) is developed to fix this. It can read configuration from other environments, among other things.  
+Its output can be piped into Garp to distribute to the right environment, like this:
+
+```
+12g env list -e staging -o json | g cdn distribute
+```
+
+### Version 3.11.30
+
+A little late to the party, but as of this version `12g` is a requirement for Garp deployment using Capistrano. The `--to` parameter of `g cdn distribute` is officially deprecated and will trigger a warning.
+
+
 ## Version 3.10
 
 Asset URL generation has changed once more.

--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -37,7 +37,17 @@ task :distribute_assets do
     run_locally do
         env = fetch(:stage)
         since_argument = ENV['distribute_since'] ? "--since=#{ENV['distribute_since']}" : ''
-        execute "[ ! \"$(vendor/bin/g config get cdn.readonly)\" ]; vendor/bin/g cdn distribute --to=#{env} #{since_argument}"
+        has_12g = capture('[ -z `which "12g"` ] && echo 0 || echo 1').strip == '1'
+        if not has_12g
+            abort "The command 12g should be executable in order to distribute assets."
+            return false
+        end
+        if capture("12g env get -e #{env} --var=CDN_READONLY").empty?
+            env_list_json = capture("12g env list -e #{env} -o json ")
+            execute "echo '#{env_list_json}' | vendor/bin/g cdn distribute #{since_argument}"
+        else
+            puts 'CDN is read-only. Not distributing.'
+        end
     end
 end
 

--- a/library/Garp/Cli/Command/Cdn.php
+++ b/library/Garp/Cli/Command/Cdn.php
@@ -33,6 +33,17 @@ class Garp_Cli_Command_Cdn extends Garp_Cli_Command {
      * @return void
      */
     public function distribute(array $args) {
+        if (f\prop('to', $args)) {
+            Garp_Cli::errorOut('"to" is a deprecated parameter.');
+            Garp_Cli::lineOut(
+                'Please use npm package 12g to pipe credentials of the target environment ' .
+                "into Garp.\n" .
+                " 👉  https://www.npmjs.com/package/12g\n\n" .
+                "Usage:\n\n" .
+                "12g env list -e {$args['to']} -o json | g cdn distribute\n"
+            );
+            return false;
+        }
         $filterString = $this->_getFilterString($args);
         $filterDate = $this->_getFilterDate($args);
         $cdnConfig = $this->_gatherConfigVars();

--- a/library/Garp/Cli/Command/Cdn.php
+++ b/library/Garp/Cli/Command/Cdn.php
@@ -32,7 +32,7 @@ class Garp_Cli_Command_Cdn extends Garp_Cli_Command {
      * @param array $args
      * @return void
      */
-    public function distribute(array $args) {
+    public function distribute(array $args): bool {
         if (f\prop('to', $args)) {
             Garp_Cli::errorOut('"to" is a deprecated parameter.');
             Garp_Cli::lineOut(
@@ -54,7 +54,7 @@ class Garp_Cli_Command_Cdn extends Garp_Cli_Command {
 
         if (!$assetList) {
             Garp_Cli::errorOut("No files to distribute.");
-            return;
+            return false;
         }
 
         $summary = $this->_getReportSummary($assetList, $filterDate);
@@ -62,7 +62,7 @@ class Garp_Cli_Command_Cdn extends Garp_Cli_Command {
 
         if ($isDryRun) {
             Garp_Cli::lineOut(implode("\n", (array)$assetList));
-            return;
+            return true;
         }
 
         $distributor->distribute(
@@ -78,6 +78,7 @@ class Garp_Cli_Command_Cdn extends Garp_Cli_Command {
 
         Garp_Cli::lineOut("\n√ Done");
         echo "\n\n";
+        return true;
     }
 
     public function help() {

--- a/scripts/garp.php
+++ b/scripts/garp.php
@@ -177,8 +177,8 @@ if (!in_array($classArgument, $commandsWithoutTranslation)) {
     }
 }
 
-$command->main($args);
+$response = $command->main($args);
 
 // @codingStandardsIgnoreStart
-exit(0);
+exit(!!$response ? 0 : 1);
 // @codingStandardsIgnoreEnd


### PR DESCRIPTION
Pff, het was wat meer werk om het aan elkaar te lijmen dan ik hoopte. 
Maar `g cdn distribute` binnen Capistrano maakt nu gebruik van 12g om de credentials van de target environment op te halen.

Eén gotcha: ik heb een JSON gem nodig om de respons te parsen van `12g env list`. Daarmee kan ik dan weer kijken of het CDN als _read-only_ staat gemarkeerd en dan sla ik het distribueren over.

Maar zie dat er nu niet echt een plek is om Ruby dependencies te definiëren binnen Garp? 
Dat zou betekenen dat projecten die hier gebruik van maken _zelf_ die json gem op de kop moeten tikken. (en dat we dus een breaking change binnen Garp hebben en een versie omhoog moeten)

Wat zijn jullie ideeën daarover?