### PR TITLE
Allow empty tags as deployed version in Slack

### DIFF
--- a/deploy/tasks/garp.cap
+++ b/deploy/tasks/garp.cap
@@ -22,7 +22,7 @@ desc "Notify Slack"
 task :notify_slack do
     on roles(:app) do
         within release_path do
-            execute "php #{release_path}/vendor/grrr-amsterdam/garp3/scripts/garp.php Slack sendDeployNotification --branch=#{fetch(:branch)} --user=#{fetch(:local_user)} --git-version=#{capture("cd #{repo_path} && git describe #{fetch(:branch)}")} --e=#{fetch(:stage)}"
+            execute "php #{release_path}/vendor/grrr-amsterdam/garp3/scripts/garp.php Slack sendDeployNotification --branch=#{fetch(:branch)} --user=#{fetch(:local_user)} --git-version=#{capture("cd #{repo_path} && git describe #{fetch(:branch)} --tags")} --e=#{fetch(:stage)}"
         end
     end
 end
@@ -59,4 +59,3 @@ task :composer_install do
         execute "if [ -f #{composerPharPath} ]; then php #{composerPharPath} install -d #{release_path} --no-dev; fi"
     end
 end
-


### PR DESCRIPTION
> `--tags`
> Instead of using only the annotated tags, use any tag found in refs/tags namespace. This option enables matching a lightweight (non-annotated) tag.

So we'll get `v1.52.1-11-gb4659a72` instead of `v1.50.2-137-gb4659a72` (last tag which wasn't empty)