### PR TITLE
Remove type check on error handler

### DIFF
--- a/library/Garp/ErrorHandler.php
+++ b/library/Garp/ErrorHandler.php
@@ -200,7 +200,7 @@ class Garp_ErrorHandler {
         return in_array(strtolower($string[0]), $vowels);
     }
 
-    protected static function _composeFullErrorMessage(ArrayObject $errors) {
+    protected static function _composeFullErrorMessage($errors) {
         $appName = self::_getApplicationName();
         $errorMessage = "Application: {$appName}\n\n";
         $errorMessage .= "Exception: {$errors->exception->getMessage()}\n\n";


### PR DESCRIPTION
```
Argument 1 passed to Garp_ErrorHandler::_composeFullErrorMessage() must be an instance of ArrayObject, instance of Zend_Controller_Plugin_ErrorHandler given, called in /home/melkweg/html/melkweg.nl/public/releases/20180215105924/vendor/grrr-amsterdam/garp3/library/Garp/ErrorHandler.php on line 45
```

Sentry error `Zend_Controller_Plugin_ErrorHandler` given instead of . See https://sentry.io/grrr/melkweg/issues/426019399/

Similar issue as: https://github.com/grrr-amsterdam/garp3/commit/a5d7459eb97467a02580db2c396e2f3d7578de4a#diff-31cc35b8624fdfc32e176fd574226e86.

