### PR TITLE
Add spawn call to Capistrano deploy task to ensure consistent models

### DIFF
--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -2,7 +2,8 @@ desc "Build assets"
 task :build_assets do
     run_locally do
         env = fetch(:stage)
-            execute "yarn && gulp --e=#{env}"
+        execute "./vendor/bin/g spawn --only=js"
+        execute "yarn && gulp --e=#{env}"
     end
 end
 


### PR DESCRIPTION
Since assets are scp'd from your local machine, we have to make sure we
generate base- and extended model files before uploading to get
consistent results.