### PR TITLE
Invoke OPcache reset on the CLI during deploy with separate task

### DIFF
--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -31,7 +31,7 @@ namespace :deploy do
         # Set under construction
         invoke :enable_under_construction
 
-        invoke :clear_cache
+        invoke :clear_cli_opcache
     end
 
     after :updated, :after_updated do

--- a/deploy/tasks/garp.cap
+++ b/deploy/tasks/garp.cap
@@ -65,3 +65,10 @@ task :clear_cache do
 		execute "php #{release_path}/vendor/grrr-amsterdam/garp3/scripts/garp.php cache clear --opcache --e=#{fetch(:stage)}"
 	end
 end
+
+desc "Clear PHP OPcache on the CLI"
+task :clear_cli_opcache do
+	on roles(:web) do
+		execute "php -r \"if (function_exists('opcache_reset')) opcache_reset();\""
+	end
+end


### PR DESCRIPTION
This way we avoid the dreaded...

> Capistrano tasks may only be invoked once. Since task `clear_cli_opcache' was previously invoked, invoke("clear_cli_opcache") at vendor/grrr-amsterdam/garp3/deploy/garp3.cap:35 will be skipped.
> If you really meant to run this task again, use invoke!("clear_cli_opcache")
> THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
> https://github.com/capistrano/capistrano/issues/1686

... and only clear the OPcache on the CLI with a simple task. 