### PR TITLE
Invoke OPcache reset on the CLI during deploy with separate task

### DIFF
--- a/deploy/garp3.cap
+++ b/deploy/garp3.cap
@@ -28,7 +28,7 @@ namespace :deploy do
         # Set under construction
         invoke :enable_under_construction
 
-        invoke :clear_cache
+        invoke :clear_cli_opcache
     end
 
     after :updated, :after_updated do

--- a/deploy/tasks/garp.cap
+++ b/deploy/tasks/garp.cap
@@ -65,3 +65,10 @@ task :clear_cache do
 		execute "php #{release_path}/vendor/grrr-amsterdam/garp3/scripts/garp.php cache clear --opcache --e=#{fetch(:stage)}"
 	end
 end
+
+desc "Clear PHP OPcache on the CLI"
+task :clear_cli_opcache do
+	on roles(:web) do
+		execute "php -r \"if (function_exists('opcache_reset')) opcache_reset();\""
+	end
+end


### PR DESCRIPTION
Capistrano doesn't run a command twice, so we invoke a custom function