### PR TITLE
Update Sentry tags

### DIFF
--- a/application/init.php
+++ b/application/init.php
@@ -29,7 +29,16 @@ if (file_exists(APPLICATION_PATH . '/../.env')) {
 // Sentry integration
 if (getenv('SENTRY_API_URL') || (defined('SENTRY_API_URL') && APPLICATION_ENV !== 'development')) {
     $sentryApiUrl = getenv('SENTRY_API_URL') ?: SENTRY_API_URL;
-    $ravenClient = new Raven_Client($sentryApiUrl);
+    $ravenClient = new Raven_Client(
+        $sentryApiUrl,
+        array(
+            'environment' => APPLICATION_ENV,
+            'release' => (string)new Garp_Version,
+            'tags' => array(
+                'php_version' => phpversion(),
+            ),
+        )
+    );
     $ravenErrorHandler = new Raven_ErrorHandler($ravenClient);
     $ravenErrorHandler->registerExceptionHandler();
     $ravenErrorHandler->registerErrorHandler();

--- a/library/Garp/Service/Sentry.php
+++ b/library/Garp/Service/Sentry.php
@@ -40,36 +40,28 @@ class Garp_Service_Sentry {
             return;
         }
 
-        $debugVars = $this->_getBasicVars();
-        $debugVars += $this->_getUserVars();
-
-        $varList = array('extra' => $debugVars);
-
         $ravenClient = Zend_Registry::get('RavenClient');
-        $ravenClient->setRelease((string)new Garp_Version);
         $event_id = $ravenClient->getIdent(
-            $ravenClient->captureException($exception, $varList)
+            $ravenClient->captureException(
+                $exception,
+                array(
+                    'extra' => $this->_getBasicVars(),
+                    'user' => $this->_getUserVars(),
+                )
+            )
         );
     }
 
-    protected function _getBasicVars() {
+    protected function _getBasicVars(): array {
         return array(
-            '_php_version' => phpversion(),
-            '_garp_version' => $this->_readGarpVersion(),
-            'extensions' => get_loaded_extensions()
+            'garp_version' => $this->_readGarpVersion(),
         );
     }
 
-    protected function _getUserVars() {
+    protected function _getUserVars(): array {
         // Add logged in user data to log
         $auth = Garp_Auth::getInstance();
-        $output = array();
-
-        if ($auth->isLoggedIn()) {
-            $output['_user_data'] = $auth->getUserData();
-        };
-
-        return $output;
+        return $auth->isLoggedIn() ? $auth->getUserData() : array();
     }
 
     /**


### PR DESCRIPTION
- Add environment and release to logged errors
- Initialize Sentry with those tags, instead of only using them when custom loggin (also know as 'never')
- Move additional custom log tags to proper structure (`extra` and `user`)
- Dropped `extensions`, since those would need to be convert to a string and don't much information anyway

---

This should add `environment` and `release` to Sentry error logging, since that's now missing from Garp projects. Most errors are exceptions, which aren't triggered as a custom logged error. So initializing Sentry with those variables should send them along in all situations.

PS: would like to add `garp_version` in the future, but it's now part of `Garp_Service_Sentry`, and `Garp_Version` is already taken by the 'release version'.