### PR TITLE
Check for interactivity before reading STDIN

### DIFF
--- a/scripts/garp.php
+++ b/scripts/garp.php
@@ -118,9 +118,12 @@ if (empty($args[0])) {
 /**
  * Read STDIN
  */
-stream_set_blocking(STDIN, false);
-$stdin = trim(stream_get_contents(STDIN));
-stream_set_blocking(STDIN, true);
+$stdin = '';
+if (!posix_isatty(STDIN)) {
+    stream_set_blocking(STDIN, true);
+    stream_set_timeout(STDIN, 1);
+    $stdin = trim(stream_get_contents(STDIN));
+}
 
 /* Construct command classname */
 $classArgument = ucfirst($args[0]);


### PR DESCRIPTION
`posix_isatty` can be used to determine wether data is being piped into a
script.

Using this, we can revert `stream_set_blocking()` to `true`, in order to
make the script wait for all input.

Specifically fixes a case where remote data (which takes a while to be
downloaded) from `12g` was not being picked up by `garp.php`.