### PR TITLE
Remove default exposed Docker ports

### DIFF
--- a/docker-garp3.yml
+++ b/docker-garp3.yml
@@ -2,15 +2,11 @@ version: '2'
 services:
   garp_web:
     image: grrrnl/garp3-httpd:3.9
-    ports:
-      - "80:80"
     volumes:
       - ../../..:/var/www/html
     privileged: true
   garp_db:
     image: grrrnl/garp3-db
-    ports:
-      - "3306:3306"
     restart: always
   garp_dbdata:
     image: grrrnl/garp3-data


### PR DESCRIPTION
We no longer expose default Docker ports. This prevents conflicts with any running services like web server or database on the host system.