### PR TITLE
Improve detection of name fields

### DIFF
--- a/library/Garp/Model/Db/Faker.php
+++ b/library/Garp/Model/Db/Faker.php
@@ -129,10 +129,10 @@ class Garp_Model_Db_Faker {
         if ($name === 'name') {
             return $this->_faker->sentence;
         }
-        if ($name === 'first_name') {
+        if (f\either(f\contains('first_name'), f\contains('voornaam'))($name)) {
             return $this->_faker->firstName;
         }
-        if ($name === 'last_name') {
+        if (f\either(f\contains('last_name'), f\contains('achternaam'))($name)) {
             return $this->_faker->lastName;
         }
         return $this->_faker->text(
@@ -143,5 +143,6 @@ class Garp_Model_Db_Faker {
         );
     }
 }
+
 
 


### PR DESCRIPTION
- Check for substrings rather than full matches, to pick up columns
  where first/last names are prefixed or suffixed.
- Also, pick up on Dutch column names.


@HammenWS This fixes the Subsidieportaal problems where the fake name data would get truncated.