### PR TITLE
Fix checking for --e argument

### DIFF
--- a/scripts/garp.php
+++ b/scripts/garp.php
@@ -12,7 +12,7 @@ date_default_timezone_set('Europe/Amsterdam');
 // Check if APPLICATION_ENV is passed along as an argument.
 foreach ($_SERVER['argv'] as $key => $arg) {
     if (substr($arg, 0, 17) === '--APPLICATION_ENV'
-        || substr($arg, 0, 3)  === '--e'
+        || $arg === '--e'
     ) {
         $keyAndVal = explode('=', $arg);
         define('APPLICATION_ENV', trim($keyAndVal[1]));


### PR DESCRIPTION
The current check won't allow any other argument starting with an 'e'.
It's unbelievable it took us all these years before ever encountering
this problem.