### PR TITLE
Replace scp for rsync for faster assets distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,24 @@
 language: php
+
 php:
     - '7.1'
-sudo: false
-dist: trusty
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - composer install
+
+before_script:
+  - chmod -R +x vendor/bin/phpunit
+  - chmod -R +x vendor/bin/phpcs
+
 script:
     - composer test
     - if [ "$(git diff --diff-filter=ACMR --name-only HEAD^..HEAD -- '*.php')" != "" ]; then ./vendor/bin/phpcs --standard=phpcs.xml --colors --encoding=utf-8 -n -p $(git diff --diff-filter=ACMR --name-only HEAD^..HEAD -- '*.php'); fi
-before_script:
-    - chmod -R +x vendor/bin/phpunit
-    - chmod -R +x vendor/bin/phpcs
-before_install:
-    - composer install
+
 notifications:
   email: false
   slack:

--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -20,8 +20,6 @@ task :push_assets do
             execute "scp rev-manifest-*.json #{host.user}@#{host.hostname}:#{release_path}"
             execute "scp -r public/css/build/* #{host.user}@#{host.hostname}:#{release_path}"\
                 "/public/css/build/"
-            execute "scp -r public/css/build/* #{host.user}@#{host.hostname}:#{release_path}"\
-                "/public/css/build/"
             execute "scp -r public/js/build/* #{host.user}@#{host.hostname}:#{release_path}"\
                 "/public/js/build/"
         end

--- a/deploy/tasks/assets.cap
+++ b/deploy/tasks/assets.cap
@@ -10,17 +10,11 @@ end
 desc "Push built assets to the webserver"
 task :push_assets do
     on roles(:web) do |host|
-        execute "mkdir -p "\
-            "#{release_path}/public/css/build/staging "\
-            "#{release_path}/public/css/build/prod "\
-            "#{release_path}/public/js/build/staging "\
-            "#{release_path}/public/js/build/prod "
-
         run_locally do
-            execute "scp rev-manifest-*.json #{host.user}@#{host.hostname}:#{release_path}"
-            execute "scp -r public/css/build/* #{host.user}@#{host.hostname}:#{release_path}"\
+            execute "rsync rev-manifest-*.json #{host.user}@#{host.hostname}:#{release_path}"
+            execute "rsync -r public/css/build/* #{host.user}@#{host.hostname}:#{release_path}"\
                 "/public/css/build/"
-            execute "scp -r public/js/build/* #{host.user}@#{host.hostname}:#{release_path}"\
+            execute "rsync -r public/js/build/* #{host.user}@#{host.hostname}:#{release_path}"\
                 "/public/js/build/"
         end
     end


### PR DESCRIPTION
`rsync` only transfers changes so it's much faster than `scp` especially when the assets didn't change.

`rsync` creates folders so `mkdir` becomes useless. 