### PR TITLE
Fix: GridPanel keyboard navigation for Firefox CMS users.

### DIFF
--- a/public/js/overrides.js
+++ b/public/js/overrides.js
@@ -713,3 +713,8 @@ Ext.override(Ext.grid.PropertyColumnModel, {
 		return (col === 0 ? this.requiredPropertyRenderer.createDelegate(this) : (this.renderCellDelegate || this.renderPropDelegate));
 	}
 });
+
+/**
+ * Fixes a bug in Firefox where keyNav on gridPanel's not working.
+ */
+Ext.KeyNav.prototype.forceKeyDown = true;


### PR DESCRIPTION
This fixes a long standing CMS issue for Firefox users. Keyboard navigation (mainly `up` and `down` arrow keys) didn't work anymore.

N.B. This fix is tested on Firefox, Chrome and Safari.