### PR TITLE
Remove `restart: always` from garp_db

### DIFF
--- a/docker-garp3.yml
+++ b/docker-garp3.yml
@@ -7,7 +7,6 @@ services:
     privileged: true
   garp_db:
     image: grrrnl/garp3-db
-    restart: always
   garp_dbdata:
     image: grrrnl/garp3-data
     volumes:


### PR DESCRIPTION
`restart` is useful for orchestration, but not for local development. By removing this line the service won't restart automatically.