### PR TITLE
Remove auto sizing column width excel export

### DIFF
--- a/library/Garp/Content/Export/Excel.php
+++ b/library/Garp/Content/Export/Excel.php
@@ -82,13 +82,12 @@ class Garp_Content_Export_Excel extends Garp_Content_Export_Abstract {
             ),
         );
 
-        // set autosize = true for every column, also add alternate styles to header cells
+        // add alternate styles to header cells
         for ($i = 0, $colCount = count(array_keys($rowset[0])), $char = 'A';
             $i < $colCount;
             $i++, $char++
         ) {
             $phpexcel->getActiveSheet()->getStyle($char . '1')->applyFromArray($styleArray);
-            $phpexcel->getActiveSheet()->getColumnDimension($char)->setAutoSize(true);
         }
 
     }


### PR DESCRIPTION
Autosizing the column width in excel exports is not essential, slows the process down a lot and most importantly, relies on a function in PhpExcel that assumes casting a float to a string will put a `.` as a decimal point, which is not true if the server has for example a Dutch locale, therefor breaking the export.