### PR TITLE
Fix for dynamic values in csv exporter

### DIFF
--- a/library/Garp/Content/Export/Csv.php
+++ b/library/Garp/Content/Export/Csv.php
@@ -40,19 +40,12 @@ class Garp_Content_Export_Csv extends Garp_Content_Export_Abstract {
     }
 
     protected function _flatten(array $row): array {
-        return f\reduce_assoc(
-            function ($row, $value, $key) {
-                // In the case of related hasMany or hasAndBelongsToMany
-                // rowsets...
-                return f\prop_set(
-                    $key,
-                    is_array($value)
-                        ? implode(', ', $this->_flatten($value))
-                        : $value,
-                    $row
-                );
+        return f\map(
+            function ($value) {
+                return is_array($value)
+                    ? implode(', ', $this->_flatten($value))
+                    : $value;
             },
-            [],
             $row
         );
     }


### PR DESCRIPTION
Values that get exported to csv could be strings that correspond to functions, e.g. `dir`. This leads to unpredictable behavior of the exporter as `prop_set` also allows callable functions. By using map in this way, the function gets simpler and is freed from the unpredictability.