### PR TITLE
Prevent bypassing row object

### DIFF
--- a/library/Garp/Content/Manager.php
+++ b/library/Garp/Content/Manager.php
@@ -218,12 +218,12 @@ class Garp_Content_Manager {
             if (!$isCountQuery) {
                 $select->limit($options['limit'], $options['start']);
             }
-            $results = $this->_model->fetchAll($select)->toArray();
+            $results = $this->_model->fetchAll($select);
         } else {
             $results = $this->_model->fetchAll();
         }
 
-        foreach ($results as &$result) {
+        foreach ($results as $result) {
             foreach ($result as $column => $value) {
                 if (strpos($column, '.') !== false) {
                     $keyParts = explode('.', $column, 2);
@@ -236,7 +236,7 @@ class Garp_Content_Manager {
                 }
             }
         }
-        return $results;
+        return is_array($results) ? $results : $results->toArray();
     }
 
 


### PR DESCRIPTION
`Zend_Db_Table_Rowset_Abstract::toArray` only works after one iteration. By calling `toArray` later in `Garp_Content_Manager` the first iteration is already done. `toArray` will be called on the row objects instead of directly returning the array from the database. Logic added to `init` inside the row object will be executed.