### PR TITLE
Set API content-type to JSON

### DIFF
--- a/application/modules/g/controllers/RestController.php
+++ b/application/modules/g/controllers/RestController.php
@@ -30,6 +30,10 @@ class G_RestController extends Garp_Controller_Action {
             'Access-Control-Allow-Methods',
             implode(', ', $this->_validMethods)
         );
+        $this->getResponse()->setHeader(
+            'Content-Type',
+            'application/json'
+        );
     }
 
     public function apiAction() {

--- a/library/Garp/Cli/Command/Models.php
+++ b/library/Garp/Cli/Command/Models.php
@@ -1,4 +1,7 @@
 <?php
+
+use Garp\Functional as f;
+
 /**
  * Garp_Cli_Command_Models
  * class description
@@ -23,7 +26,7 @@ class Garp_Cli_Command_Models extends Garp_Cli_Command {
         $className = "Model_{$args[0]}";
         $model = new $className();
         $fields = $model->getConfiguration('fields');
-        $fields = array_filter($fields, not(propertyEquals('name', 'id')));
+        $fields = f\reject(f\prop_equals('name', 'id'), $fields);
 
         $mode = $this->_getInsertionMode();
         if ($mode === 'g') {

--- a/library/Garp/Content/Api/Rest.php
+++ b/library/Garp/Content/Api/Rest.php
@@ -476,11 +476,11 @@ class Garp_Content_Api_Rest {
         $modelName = $this->_normalizeModelName($datatype);
         $rootModel = new $modelName;
         $schema = (new Garp_Content_Api_Rest_Schema('rest'))->getModelDetails($datatype);
-        $hasOneRelations = array_filter($schema['fields'], propertyEquals('origin', 'relation'));
+        $hasOneRelations = f\filter(f\prop_equals('origin', 'relation'), $schema['fields']);
         $hasOneRelations = array_map(f\prop('relationAlias'), $hasOneRelations);
 
         // Check validity of 'with'
-        $unknowns = array_filter($with, callRight(not('in_array'), $hasOneRelations));
+        $unknowns = f\reject(f\partial_right('in_array', $hasOneRelations), $with);
         if (count($unknowns)) {
             $err = sprintf(
                 Garp_Content_Api_Rest_Schema::EXCEPTION_RELATION_NOT_FOUND, $datatype,
@@ -495,9 +495,9 @@ class Garp_Content_Api_Rest {
             function ($acc, $cur) use ($datatype, $schema, $self) {
                 // Grab foreign key names from the relation
                 $foreignKey = current(
-                    array_filter(
-                        $schema['fields'],
-                        propertyEquals('relationAlias', $cur)
+                    f\filter(
+                        f\prop_equals('relationAlias', $cur),
+                        $schema['fields']
                     )
                 );
 

--- a/library/Garp/Content/Api/Rest/Schema.php
+++ b/library/Garp/Content/Api/Rest/Schema.php
@@ -1,4 +1,7 @@
 <?php
+
+use Garp\Functional as f;
+
 /**
  * Garp_Content_Api_Rest_Schema
  * class description
@@ -75,7 +78,7 @@ class Garp_Content_Api_Rest_Schema {
 
     protected function _getModelByName($modelName) {
         $models = $this->_getVisibleModels();
-        $modelsWithName = array_filter($models, propertyEquals('id', $modelName));
+        $modelsWithName = f\filter(f\prop_equals('id', $modelName), $models);
         if (!count($modelsWithName)) {
             throw new Garp_Content_Api_Rest_Exception_ModelNotFound(
                 sprintf(self::EXCEPTION_MODEL_NOT_FOUND, $modelName)


### PR DESCRIPTION
Change API `Content-Type` from default `text/html` to `application/json`.

Removed some usage of removed functions.