### PR TITLE
Allow option searchable in model configuration

### DIFF
--- a/application/modules/g/views/scripts/spawn/js/base_model.phtml
+++ b/application/modules/g/views/scripts/spawn/js/base_model.phtml
@@ -224,6 +224,10 @@ Garp.dataTypes.<?php echo $model->id ?> = new Garp.DataType({
 						}
 				endswitch;
 
+                if (isset($field->searchable)):
+                    $nodeParams['searchable'] = $field->searchable;
+                endif;
+
 				if (
 					!$this->spawnJs()->isListField($field->name, $model) ||
 					!$field->visible ||
@@ -439,3 +443,4 @@ Garp.dataTypes.<?php echo $model->id ?> = new Garp.DataType({
 ?>
 	}]
 });
+

--- a/library/Garp/Spawn/Field.php
+++ b/library/Garp/Spawn/Field.php
@@ -42,6 +42,7 @@ class Garp_Spawn_Field {
     public $multilingual = false;
     public $comment;
     public $wysiwyg = false;
+    public $searchable = null;
 
     /**
      * Used for relation foreign key fields. Defines the model related thru this foreign key field.


### PR DESCRIPTION
This enables authors to manually enable or disable the searchable
property used in the CMS. By default, only text columns get searchable:
true, but by specifying `searchable: true` in the model config, any
column becomes searchable.

The reverse is possible as well: any text column configured with
`searchable: false` will stop being searchable.