### PR TITLE
PHPUnit 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "vlucas/phpdotenv": "^3.4",
     "fzaninotto/faker": "^1.8",
     "grrr-amsterdam/garp-functional": "^4.0",
-    "phpunit/phpunit": "^6.0",
+    "phpunit/phpunit": "^6.0|^7",
     "greenlion/php-sql-parser": "^4.1",
     "league/csv": "^8.0",
     "aws/aws-sdk-php": "^3.87",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,6 @@
     convertNoticesToExceptions="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutOutputDuringTests="true"
-    beStrictAboutTestSize="true"
     verbose="true"
     colors="true">
 


### PR DESCRIPTION
To prevent conflicts with project who want to use PHPUnit 7 I've changed the version constraint. No BC changes between PHPUnit 6 or 7 that affect Garp.

Another option (see e076d49) is to remove PHPUnit as a dependency and add it as a suggestion. I ditched that change because `Garp_Test_PHPUnit_TestCase` extends PHPUnit which makes PHPUnit a library requirement.