### PR TITLE
Restore partial, snippet and __ in removed-functions.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ For every (necessary) backward-incompatible Garp update we create a new tag, wit
 
 (not entirely semver-compatible, we know, but historically more compatible with how we came to Garp version 3 in the first place)
 
+## Version 3.19.4
+
+The functions `partial()`, `snippet()` and `__()` where moved to `\Garp\` namespace in `3.19.0`, but not added to `removed-functions.php`. To make `removed-functions.php` a complete drop-in fix when upgrading to `v.3.19` the functions where re-added to that file.
+
 ## Version 3.19.3
 
 Change API response `Content-Type` to `application/json`.
@@ -15,10 +19,20 @@ Add spawn input property [`searchable`](https://github.com/grrr-amsterdam/garp3/
 
 vlucas/phpdotenv has been upgraded from `v2.0.1` to `^v3.4`. An overview of parsing modifications can be found in [vlucas/phpdotenv/UPGRADING.md](https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md). Check your `.env` file for possible consequences.
 
-To prevent conflicts between Garp3 and Laravel some global functions have been removed. Most of the functions could be replaced by their [Garp Functional](https://grrr-amsterdam.github.io/garp-functional) equivalent. Some need more attention. The original functions still exist in `application/removed-functions.php`. You could include that file (partially) to stay compatible, but to become compatible with Laravel you can't use that solution. `view()` and some other functions are also implemented by Laravel helpers. 
+To prevent conflicts between Garp3 and Laravel some global functions have been removed. Most of the functions could be replaced by their [Garp Functional](https://grrr-amsterdam.github.io/garp-functional) equivalent. Some need more attention. The original functions still exist in `application/removed-functions.php`. You could include that file to stay compatible.
+
+    # composer.json
+    "autoload": {
+        "files": [
+            "vendor/grrr-amsterdam/garp3/application/removed-functions.php"
+        ]
+    }
+
+To become compatible with Laravel you can't use `removed-functions.php`. `view()` and some other functions are also implemented by Laravel helpers. Which causes conflicts.
 
 Removed functions:
 
+- `__()`*
 - `array_get()`
 - `array_get_subset()`
 - `array_pluck()`
@@ -35,12 +49,16 @@ Removed functions:
 - `model()`
 - `noop()`
 - `not()`
+- `partial()`*
 - `propertyEquals()`
 - `psort()`
+- `snippet()`*
 - `some()`
 - `unary()`
 - `view()`
 - `when()`
+
+\* Moved to `\Garp` namespace. 
 
 Removed polyfills:
 

--- a/application/removed-functions.php
+++ b/application/removed-functions.php
@@ -14,6 +14,28 @@ function model(string $modelSuffix) {
 }
 
 /**
+ * Grab the rendered output of a snippet.
+ *
+ * @param string $identifier
+ * @return string
+ */
+function snippet(string $identifier): string {
+    $model = new Model_Snippet();
+    if ($model->isMultilingual()) {
+        $model = (new Garp_I18n_ModelFactory())->getModel('Snippet');
+    }
+    $snippet = $model->fetchByIdentifier($identifier);
+    if (!$snippet) {
+        return $identifier;
+    }
+    return strval(
+        $snippet->has_html
+            ? $snippet->html
+            : $snippet->text
+    );
+}
+
+/**
  * Quick access to the view.
  *
  * @return Zend_View_Abstract
@@ -24,6 +46,19 @@ function view(): Zend_View_Abstract {
     return Zend_Controller_Action_HelperBroker::getStaticHelper('viewRenderer')->view;
 }
 
+/**
+ * Render a partial.
+ *
+ * @param string $filename
+ * @param array $params
+ * @param string $module
+ * @return string
+ */
+function partial(string $filename, array $params = [], string $module = 'default'): string {
+    return Zend_Controller_Action_HelperBroker::getStaticHelper('viewRenderer')
+        ->view
+        ->partial($filename, $module, $params);
+}
 
 /**
  * Shortcut to logging messages.
@@ -44,6 +79,20 @@ function dump($file, $message, $priority = Zend_Log::INFO) {
     $logger = Garp_Log::factory($file);
     $message = is_array($message) ? print_r($message, true) : $message;
     $logger->log($message, $priority);
+}
+
+/**
+ * Translate text
+ *
+ * @param string $str
+ * @return string
+ */
+function __($str) {
+    if (Zend_Registry::isRegistered('Zend_Translate')) {
+        $translate = Zend_Registry::get('Zend_Translate');
+        return call_user_func_array(array($translate, '_'), func_get_args());
+    }
+    return $str;
 }
 
 /**


### PR DESCRIPTION
Some changes to make upgrading Garp3 apps without Laravel from `v3.18` to `v3.19` more easy.