### PR TITLE
Prevent warning when duration validator gets non numeric input

### DIFF
--- a/library/Garp/Validate/Duration.php
+++ b/library/Garp/Validate/Duration.php
@@ -21,7 +21,7 @@ class Garp_Validate_Duration extends Zend_Validate_Abstract {
     );
 
     public function isValid($value) {
-        if (time() - $value <= self::MIN_DURATION) {
+        if (!is_numeric($value) || time() - $value <= self::MIN_DURATION) {
             $this->_error(self::DURATION_TOO_SHORT);
             return false;
         }

--- a/tests/library/Garp/Validate/DurationTest.php
+++ b/tests/library/Garp/Validate/DurationTest.php
@@ -1,0 +1,35 @@
+
+<?php
+/**
+ * Garp_Validate_DurationTest
+ * Tests Garp_Validate_Duration
+ *
+ * @package Tests
+ * @author  Martijn Gastkemper <martijn@grrr.nl>
+ * @group   Validate
+ */
+class Garp_Validate_DurationTest extends Garp_Test_PHPUnit_TestCase {
+
+    /**
+     * @dataProvider data
+     * 
+     * @param mixed $value
+     * @param bool $expected
+     */
+    public function test_validate($value, bool $expected) {
+        $validator = new Garp_Validate_Duration();
+        $this->assertSame($expected, $validator->isValid($value));
+    }
+
+    public function data() {
+        return [
+            [123, true],
+            [123.0, true],
+            ["asdf", false],
+            ["123", true],
+            ["123.0", true],
+            [time() + 10, false],
+            [time() - 10, true],
+        ];
+    }
+}


### PR DESCRIPTION
`Warning: A non-numeric value encountered in /var/www/html/vendor/grrr-amsterdam/garp3/library/Garp/Validate/Duration.php on line 24`

On the break of Hacktoberfest ;-)