### PR TITLE
Make Rowset return instances of static to make it extendable

### DIFF
--- a/library/Garp/Db/Table/Rowset.php
+++ b/library/Garp/Db/Table/Rowset.php
@@ -23,7 +23,7 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
                 sprintf('Unable to concatenate semigroups %s and %s', get_class($this), get_class($that))
             );
         }
-        return new self([
+        return new static([
             'table' => $this->_table,
             'rowClass' => $this->_rowClass,
             'data' => array_merge($this->_data, $that->getData()),
@@ -54,7 +54,7 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
      */
     public function map(callable $fn) {
         $rows = array_map($fn, $this->toArray());
-        $out = new self([
+        $out = new static([
             'table'    => $this->getTable(),
             'data'     => $rows,
             'readOnly' => $this->_readOnly,
@@ -72,7 +72,7 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
      */
     public function filter($fn): Garp_Db_Table_Rowset {
         $rows = array_values(array_filter($this->toArray(), $fn));
-        $out = new self([
+        $out = new static([
             'table'    => $this->getTable(),
             'data'     => $rows,
             'readOnly' => $this->_readOnly,


### PR DESCRIPTION
Sometimes we want to extend the rowset to allow some logic on a collection of rows. Because the filter functions etc. used to return instances of the self, the return rowsets would be of Garp_Db_Table_Rowset instead of whatever type of rowset the function was called. This is now fixed by returning instances of static.

Btw, `Garp_Db_Table_Rowset::concat` doet nu een check op `instanceof self`. Dit lijkt mij eigenlijk niet afdoende. Stel, we hebben twee rowsets, die niet extended zijn en dus instance zijn van `Garp_Db_Table_Rowset`, maar bevatten wel verschillende data, ze komen uit een andere table, kunnen die nu wel concat worden. Dat lijkt me niet helemaal juist. Beter wordt hier gecheckt op of ze dezelfde `tableClass` hebben.