### PR TITLE
Use setFromArray to populate table row

### DIFF
--- a/library/Garp/Db/Table/Row.php
+++ b/library/Garp/Db/Table/Row.php
@@ -23,6 +23,15 @@ class Garp_Db_Table_Row extends Zend_Db_Table_Row_Abstract {
      */
     protected $_virtual = [];
 
+    public function __construct(array $config = [])
+    {
+        parent::__construct($config);
+
+        if (isset($config['data'])) {
+            $this->setFromArray($config['data']);
+        }
+    }
+
     public function flatten($column) {
         if (is_array($column)) {
             // Convert so it can be used by array_intersect_key


### PR DESCRIPTION
To have more control over the convertion of database data to object
values __set is used. With this change __set gets called during
construction of the row object.