### PR TITLE
Add Rowset push and shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ For every (necessary) backward-incompatible Garp update we create a new tag, wit
 
 (not entirely semver-compatible, we know, but historically more compatible with how we came to Garp version 3 in the first place)
 
+## Version 3.21.0
+
+`Garp_Db_Table_Rowset` methods `filter` and `map` will pass an actual row object into the callback, as opposed to an array.    
+This will break existing implementations that rely on the argument being an array.
+
+
 ## Version 3.20.0
 
 To enable Garp projects to use PHP v7.3 we needed an updated version of Zend Framework 1. Since it is discontinued we rely on a community supported fork of zf1, [shardj/zf1-future](https://github.com/Shardj/zf1-future/), that has replaced all v7.3 deprecated functions. It is intended to adapt to future versions of PHP as they are released.

--- a/library/Garp/Db/Table/Rowset.php
+++ b/library/Garp/Db/Table/Rowset.php
@@ -86,13 +86,14 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
         $mapped = $this->reduce(
             function (array $acc, Zend_Db_Table_Row_Abstract $row) use ($transform): array {
                 $transformed = $transform($row);
-                if ($transformed instanceof Zend_Db_Table_Row_Abstract) {
-                    $transformedArray = iterator_to_array($transformed);
+                if ($transformed instanceof Garp_Db_Table_Row) {
                     $acc[] = array_merge(
                         $transformed->toArray(),
                         $transformed->getVirtual(),
                         $transformed->getRelated()
                     );
+                } elseif ($transformed instanceof Zend_Db_Table_Row_Abstract) {
+                    $acc[] = $transformed->toArray();
                 } elseif (is_array($transformed)) {
                     $acc[] = $transformed;
                 } else {

--- a/library/Garp/Db/Table/Rowset.php
+++ b/library/Garp/Db/Table/Rowset.php
@@ -47,10 +47,10 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
         ]));
     }
 
-    public function shift(Garp_Db_Table_Row $row): Garp_Db_Table_Rowset {
+    public function prepend(Garp_Db_Table_Row $row): Garp_Db_Table_Rowset {
         if (!$row instanceof $this->_rowClass) {
             throw new LogicException(
-                sprintf('Unable to push row of type %s to this rowset. Expected: %s', get_class($row), $this->_rowClass)
+                sprintf('Unable to prepend row of type %s to this rowset. Expected: %s', get_class($row), $this->_rowClass)
             );
         }
         return (new static([

--- a/library/Garp/Db/Table/Rowset.php
+++ b/library/Garp/Db/Table/Rowset.php
@@ -97,19 +97,26 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
     /**
      * Filter a rowset using $fn
      *
-     * @param  callable $fn
+     * @param  callable $predicate
      * @return Garp_Db_Table_Rowset
      */
-    public function filter($fn): Garp_Db_Table_Rowset {
-        $rows = array_values(array_filter($this->toArray(), $fn));
-        $out = new static([
+    public function filter(callable $predicate): Garp_Db_Table_Rowset {
+        $filtered = $this->reduce(
+            function (array $acc, Zend_Db_Table_Row $row) use ($predicate): array {
+                if ($predicate($row)) {
+                    $acc[] = $row->toArray();
+                }
+                return $acc;
+            },
+            []
+        );
+        return new static([
             'table'    => $this->getTable(),
-            'data'     => $rows,
+            'data'     => $filtered,
             'readOnly' => $this->_readOnly,
             'rowClass' => $this->_rowClass,
             'stored'   => $this->_stored
         ]);
-        return $out;
     }
 
     /**

--- a/library/Garp/Db/Table/Rowset.php
+++ b/library/Garp/Db/Table/Rowset.php
@@ -87,7 +87,12 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
             function (array $acc, Zend_Db_Table_Row_Abstract $row) use ($transform): array {
                 $transformed = $transform($row);
                 if ($transformed instanceof Zend_Db_Table_Row_Abstract) {
-                    $acc[] = $transformed->toArray();
+                    $transformedArray = iterator_to_array($transformed);
+                    $acc[] = array_merge(
+                        $transformed->toArray(),
+                        $transformed->getVirtual(),
+                        $transformed->getRelated()
+                    );
                 } elseif (is_array($transformed)) {
                     $acc[] = $transformed;
                 } else {

--- a/library/Garp/Db/Table/Rowset.php
+++ b/library/Garp/Db/Table/Rowset.php
@@ -32,6 +32,36 @@ class Garp_Db_Table_Rowset extends Zend_Db_Table_Rowset_Abstract implements Semi
         ]);
     }
 
+    public function push(Garp_Db_Table_Row $row): Garp_Db_Table_Rowset {
+        if (!$row instanceof $this->_rowClass) {
+            throw new LogicException(
+                sprintf('Unable to push row of type %s to this rowset. Expected: %s', get_class($row), $this->_rowClass)
+            );
+        }
+        return $this->concat(new static([
+            'table' => $this->_table,
+            'rowClass' => $this->_rowClass,
+            'data' => [$row->toArray()],
+            'readOnly' => $this->_readOnly,
+            'stored' => $this->_stored
+        ]));
+    }
+
+    public function shift(Garp_Db_Table_Row $row): Garp_Db_Table_Rowset {
+        if (!$row instanceof $this->_rowClass) {
+            throw new LogicException(
+                sprintf('Unable to push row of type %s to this rowset. Expected: %s', get_class($row), $this->_rowClass)
+            );
+        }
+        return (new static([
+            'table' => $this->_table,
+            'rowClass' => $this->_rowClass,
+            'data' => [$row->toArray()],
+            'readOnly' => $this->_readOnly,
+            'stored' => $this->_stored
+        ]))->concat($this);
+    }
+
     /**
      * Flatten a rowset to a simpler array containing the specified columns.
      *

--- a/tests/library/Garp/Db/Table/RowsetTest.php
+++ b/tests/library/Garp/Db/Table/RowsetTest.php
@@ -99,6 +99,43 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
         $this->assertCount(3, $together->filter(f\not(f\prop('foo'))));
     }
 
+    public function testShouldShiftAndPush() {
+        $rows = new Garp_Db_Table_Rowset([
+            'data' => [
+                ['id' => 3, 'name' => 'cat'],
+                ['id' => 2, 'name' => 'dog'],
+                ['id' => 1, 'name' => 'bird']
+            ],
+            'rowClass' => 'Garp_Db_Table_Row',
+        ]);
+        $appended = $rows->shift(new Garp_Db_Table_Row([
+            'data' => ['id' => 42, 'name' => 'hyena']
+        ]));
+        $this->assertEquals(
+            [
+                ['id' => 42, 'name' => 'hyena'],
+                ['id' => 3, 'name' => 'cat'],
+                ['id' => 2, 'name' => 'dog'],
+                ['id' => 1, 'name' => 'bird'],
+            ],
+            $appended->toArray()
+        );
+
+        $appended2 = $appended->push(new Garp_Db_Table_Row([
+            'data' => ['id' => 5, 'name' => 'goldfish']
+        ]));
+        $this->assertEquals(
+            [
+                ['id' => 42, 'name' => 'hyena'],
+                ['id' => 3, 'name' => 'cat'],
+                ['id' => 2, 'name' => 'dog'],
+                ['id' => 1, 'name' => 'bird'],
+                ['id' => 5, 'name' => 'goldfish'],
+            ],
+            $appended2->toArray()
+        );
+    }
+
     public function testShouldReduce() {
         $things = new Garp_Db_Table_Rowset([
             'data' => [

--- a/tests/library/Garp/Db/Table/RowsetTest.php
+++ b/tests/library/Garp/Db/Table/RowsetTest.php
@@ -44,6 +44,17 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
                 'rowClass' => 'Garp_Db_Table_Row',
             ]
         );
+        $related = new Garp_Db_Table_Rowset(
+            [
+                'data' =>  [
+                    ['id' => 1, 'name' => 'foo'],
+                    ['id' => 2, 'name' => 'bar']
+                ],
+                'rowClass' => 'Garp_Db_Table_Row',
+            ]
+        );
+
+        $things[0]->setVirtual('Related', $related);
 
         $mappedThings = $things->map(
             function (Garp_Db_Table_Row $item) {
@@ -53,6 +64,7 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
         );
         $this->assertEquals('HENK', $mappedThings[2]->name);
         $this->assertEquals('HENDRIK', $mappedThings[0]->name);
+        $this->assertEquals('foo', $mappedThings[0]->Related[0]->name);
 
         // $things should be unchanged
         $this->assertNotSame($mappedThings->toArray(), $things->toArray());

--- a/tests/library/Garp/Db/Table/RowsetTest.php
+++ b/tests/library/Garp/Db/Table/RowsetTest.php
@@ -99,7 +99,7 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
         $this->assertCount(3, $together->filter(f\not(f\prop('foo'))));
     }
 
-    public function testShouldShiftAndPush() {
+    public function testShouldPrependAndPush() {
         $rows = new Garp_Db_Table_Rowset([
             'data' => [
                 ['id' => 3, 'name' => 'cat'],
@@ -108,7 +108,7 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
             ],
             'rowClass' => 'Garp_Db_Table_Row',
         ]);
-        $appended = $rows->shift(new Garp_Db_Table_Row([
+        $appended = $rows->prepend(new Garp_Db_Table_Row([
             'data' => ['id' => 42, 'name' => 'hyena']
         ]));
         $this->assertEquals(

--- a/tests/library/Garp/Db/Table/RowsetTest.php
+++ b/tests/library/Garp/Db/Table/RowsetTest.php
@@ -35,41 +35,40 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
 
     public function testShouldMap() {
         $things = new Garp_Db_Table_Rowset(
-            array(
-            'data'     => array(
-                array('id' => 3, 'name' => 'hendrik', 'intro' => 'lorem ipsum dolor sit amet'),
-                array('id' => 2, 'name' => 'klaas', 'intro' => 'lorem ipsum dolor sit amet'),
-                array('id' => 1, 'name' => 'henk', 'intro' => 'lorem ipsum dolor sit amet')
-            ),
-            'rowClass' => 'Garp_Db_Table_Row',
-            )
+            [
+                'data' => [
+                    ['id' => 3, 'name' => 'hendrik', 'intro' => 'lorem ipsum dolor sit amet'],
+                    ['id' => 2, 'name' => 'klaas', 'intro' => 'lorem ipsum dolor sit amet'],
+                    ['id' => 1, 'name' => 'henk', 'intro' => 'lorem ipsum dolor sit amet']
+                ],
+                'rowClass' => 'Garp_Db_Table_Row',
+            ]
         );
 
         $mappedThings = $things->map(
-            function ($item) {
-                $item['name'] = strtoupper($item['name']);
+            function (Garp_Db_Table_Row $item) {
+                $item->name = strtoupper($item->name);
                 return $item;
             }
         );
-        $this->assertEquals('Garp_Db_Table_Rowset', get_class($mappedThings));
-        $this->assertEquals('HENK', $mappedThings[2]['name']);
-        $this->assertEquals('HENDRIK', $mappedThings[0]['name']);
+        $this->assertEquals('HENK', $mappedThings[2]->name);
+        $this->assertEquals('HENDRIK', $mappedThings[0]->name);
 
         // $things should be unchanged
-        $this->assertFalse($mappedThings === $things);
-        $this->assertEquals('hendrik', $things[0]['name']);
+        $this->assertNotSame($mappedThings->toArray(), $things->toArray());
+        $this->assertEquals('hendrik', $things[0]->name);
 
         // can callback use local vars?
         $start = 0;
         $end = 1;
         $initials = $mappedThings->map(
             function ($item) use ($start, $end) {
-                $item['name'] = substr($item['name'], $start, $end);
+                $item->name = substr($item->name, $start, $end);
                 return $item;
             }
         );
-        $this->assertEquals('H', $initials[0]['name']);
-        $this->assertEquals('K', $initials[1]['name']);
+        $this->assertEquals('H', $initials[0]->name);
+        $this->assertEquals('K', $initials[1]->name);
     }
 
     public function testShouldFilter() {

--- a/tests/library/Garp/Db/Table/RowsetTest.php
+++ b/tests/library/Garp/Db/Table/RowsetTest.php
@@ -72,6 +72,22 @@ class Garp_Db_Table_RowsetTest extends Garp_Test_PHPUnit_TestCase {
         $this->assertEquals('K', $initials[1]['name']);
     }
 
+    public function testShouldFilter() {
+        $rows = new Garp_Db_Table_Rowset([
+            'data' => [
+                ['name' => 'koe'],
+                ['name' => 'paard'],
+            ],
+        ]);
+        $predicate = function (Zend_Db_Table_Row $row): bool {
+            return strlen($row->name) > 3;
+        };
+
+        $filtered = $rows->filter($predicate);
+        $this->assertCount(1, $filtered);
+        $this->assertSame('paard', $filtered[0]->name);
+    }
+
     public function testShouldConcat() {
         $these = new Garp_Db_Table_Rowset([
             'data' => [


### PR DESCRIPTION
For appending or prepending single rows to rowsets.

Same as `concat`, but when you have a single row. 

I've taken the names from `array_shift` and `array_push`, but now I'm doubting whether I shouldn't've just used `prepend` and `append`, what do you think?