### PR TITLE
Add CSV mime-type to S3 storage

### DIFF
--- a/library/Garp/File/Storage/S3.php
+++ b/library/Garp/File/Storage/S3.php
@@ -33,7 +33,8 @@ class Garp_File_Storage_S3 implements Garp_File_Storage_Protocol {
         'jpg' => 'image/jpeg',
         'png' => 'image/png',
         'gif' => 'image/gif',
-        'svg' => 'image/svg+xml'
+        'svg' => 'image/svg+xml',
+        'csv' => 'text/csv',
     ];
 
     /**


### PR DESCRIPTION
This fixes CSV files being shown plainly in the browser instead of prompted for download.

(Fix for Subsidieportaal AC-1019)