### PR TITLE
Remove breaking urldecoding on export filters

### DIFF
--- a/library/Garp/Content/Export/Abstract.php
+++ b/library/Garp/Content/Export/Abstract.php
@@ -36,7 +36,6 @@ abstract class Garp_Content_Export_Abstract {
 
         $filter = array();
         if (array_key_exists('filter', $params) && $params['filter']) {
-            $filter = urldecode($params['filter']);
             $filter = Zend_Json::decode($params['filter']);
         }
         $fetchOptions = array(


### PR DESCRIPTION
The filter param is retrieved through $_GET (See: https://github.com/Shardj/zf1-future/blob/master/library/Zend/Controller/Request/Http.php\#L747-L764). This means the values are already urldecoded (See the warning at: https://www.php.net/urldecode). Since the filter strings are wrapped within % to provide wildcards for the query, urldecoding again here can lead to unexpected behavior, especially when a filter with a number is applied. Say we are searching for "21", the filter will be "%21%". Urldecoding this will lead to the string "!%". Which is not at all what we are searching for. And since the decoding is already applied, it can be removed here.

Nog een toevoeging: Gek genoeg is het lokaal niet te reproduceren. Als ik de decoded string uitprint zie ik idd dat het verkeerd gaat, maar het uiteindelijke resultaat is wel goed. Best bijzonder...