### PR TITLE
Remove author information from extended models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ For every (necessary) backward-incompatible Garp update we create a new tag, wit
 
 (not entirely semver-compatible, we know, but historically more compatible with how we came to Garp version 3 in the first place)
 
+## Version 3.22.1
+
+Removed the need for a class docblock from `phpcs.xml`. In modern development environments all information is in a version control system. We don't think it's required anymore to have a docblock.   
+Obviously add one yourself when an explanation of the class is warranted. 
+
 ## Version 3.22.0
 
 Hostname validation has been enabled for `Garp_Form_Element_Email`. Only the local part of the email address was validated. Now domains (except localhost) are allowed, IP addresses are not allowed.

--- a/library/Garp/Spawn/Php/Model/Extended.php
+++ b/library/Garp/Spawn/Php/Model/Extended.php
@@ -23,23 +23,9 @@ class Garp_Spawn_Php_Model_Extended extends Garp_Spawn_Php_Model_Abstract {
         $model = $this->getModel();
         $parentClass = $this->_getParentClass();
 
-        // Grab author information from git
-        $authorName = trim(`git config user.name`);
-        $authorEmail = trim(`git config user.email`);
-
         $out
             = $this->_rl("<?php")
-            . $this->_rl("/**")
-            . $this->_rl(" * Model_{$model->id}")
-            . $this->_rl(" * class description")
-            . $this->_rl(" *")
-            . $this->_rl(" * @package Model")
-            . $this->_rl(" * @author  {$authorName} <{$authorEmail}>")
-            . $this->_rl(" */")
             . $this->_rl("class Model_{$model->id} extends {$parentClass} {", 0)
-            . $this->_rl("public function init() {", 1)
-            . $this->_rl('parent::init();', 2)
-            . $this->_rl('}', 1)
             . $this->_rl("}", 0, 0);
 
         return $out;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,6 +26,7 @@
     <exclude name="PEAR.Commenting.FileComment.MissingVersion"/>
     <exclude name="PEAR.Commenting.FileComment.MissingCategoryTag"/>
     <exclude name="PEAR.Commenting.FileComment.Missing"/>
+    <exclude name="PEAR.Commenting.ClassComment.Missing"/>
     <exclude name="PEAR.Commenting.FunctionComment.Missing"/>
     <exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamType"/>
     <exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamName"/>


### PR DESCRIPTION
It's a fun feature but creates a git dependency that we can do without.