### PR TITLE
Move Garp TestCase functionality to trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ For every (necessary) backward-incompatible Garp update we create a new tag, wit
 
 (not entirely semver-compatible, we know, but historically more compatible with how we came to Garp version 3 in the first place)
 
+## Version 3.23.1
+
+The functionality previously found in `Garp_Test_PHPUnit_TestCase` is now in `Garp_Test_Traits_UsesTestHelper`.   
+This allows you to extend other TestCase parent classes (like the one provided with Laravel), while still keeping Garp functionality.
+Hopefully this eases the transition to or integration with other frameworks.
+
 ## Version 3.23.0
 
 PHP 7.4 compatibility has arrived 🥰

--- a/library/Garp/Test/PHPUnit/TestCase.php
+++ b/library/Garp/Test/PHPUnit/TestCase.php
@@ -11,30 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class Garp_Test_PHPUnit_TestCase extends TestCase {
 
-    /**
-     * @var Garp_Test_PHPUnit_Helper
-     */
-    protected $_helper;
-
-    /**
-     * Fixtures
-     *
-     * @var array
-     */
-    protected $_mockData = array();
-
-    public function setUp() {
-        $this->_helper = new Garp_Test_PHPUnit_Helper();
-        $this->_helper->setUp($this->_mockData);
-        parent::setUp();
-    }
-
-    public function tearDown() {
-        if ($this->_helper) {
-            $this->_helper->tearDown($this->_mockData);
-        }
-        parent::tearDown();
-    }
+    use Garp_Test_Traits_UsesTestHelper;
 
     /**
      * Assertion for comparing arrays, ignoring the order of values

--- a/library/Garp/Test/Traits/UsesTestHelper.php
+++ b/library/Garp/Test/Traits/UsesTestHelper.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package Garp
+ * @author  Harmen Janssen <harmen@grrr.nl>
+ */
+trait Garp_Test_Traits_UsesTestHelper {
+
+    /**
+     * @var Garp_Test_PHPUnit_Helper
+     */
+    protected $_helper;
+
+    /**
+     * Fixtures
+     *
+     * @var array
+     */
+    protected $_mockData = array();
+
+    public function setUp(): void {
+        $this->_helper = new Garp_Test_PHPUnit_Helper();
+        $this->_helper->setUp($this->_mockData);
+        parent::setUp();
+    }
+
+    public function tearDown(): void {
+        if ($this->_helper) {
+            $this->_helper->tearDown($this->_mockData);
+        }
+        parent::tearDown();
+    }
+
+}

--- a/tests/application/modules/garp/views/helpers/AssetUrlTest.php
+++ b/tests/application/modules/garp/views/helpers/AssetUrlTest.php
@@ -170,7 +170,7 @@ class Garp_View_Helper_AssetUrlTest extends Garp_Test_PHPUnit_TestCase {
         return file_exists($this->_getVersionPath());
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(
@@ -188,7 +188,7 @@ class Garp_View_Helper_AssetUrlTest extends Garp_Test_PHPUnit_TestCase {
         if (!$this->_doesVersionExist()) {
             $this->_usedVersion = static::MOCK_VERSION;
             $this->_clearVersion = true;
-            return file_put_contents(
+            file_put_contents(
                 $this->_getVersionPath(),
                 static::MOCK_VERSION
             );
@@ -197,7 +197,7 @@ class Garp_View_Helper_AssetUrlTest extends Garp_Test_PHPUnit_TestCase {
         }
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
         $this->_getView()->clearVars();
         if ($this->_clearVersion) {

--- a/tests/application/modules/garp/views/helpers/ImageHelperTest.php
+++ b/tests/application/modules/garp/views/helpers/ImageHelperTest.php
@@ -46,7 +46,7 @@ class G_View_Helper_Image_Test extends Garp_Test_PHPUnit_TestCase {
         return $imageHelper;
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(

--- a/tests/library/Garp/Auth/Adapter/LinkedInTest.php
+++ b/tests/library/Garp/Auth/Adapter/LinkedInTest.php
@@ -13,7 +13,7 @@ class Garp_Auth_Adapter_LinkedInTest extends Garp_Test_PHPUnit_TestCase {
         );
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(

--- a/tests/library/Garp/Auth/Adapter/PasswordlessTest.php
+++ b/tests/library/Garp/Auth/Adapter/PasswordlessTest.php
@@ -11,9 +11,9 @@ class Garp_Auth_Adapter_PasswordlessTest extends Garp_Test_PHPUnit_TestCase {
     const TEST_EMAIL = 'thedude@garp.com';
 
     /**
-    * Wether to execute these tests, it only makes sense for projects where
-    * passwordless authentication is actually enabled.
-    */
+     * Wether to execute these tests, it only makes sense for projects where
+     * passwordless authentication is actually enabled.
+     */
     protected $_testsEnabled = false;
 
     protected $_mockData = array(
@@ -242,7 +242,7 @@ class Garp_Auth_Adapter_PasswordlessTest extends Garp_Test_PHPUnit_TestCase {
         return $transport->recipients . '.tmp';
     }
 
-    public function setUp() {
+    public function setUp(): void {
         // Only execute tests when passwordless is actually one of the configured adapters for
         // this project.
         $this->_testsEnabled = isset(Zend_Registry::get('config')->auth->adapters->passwordless);
@@ -279,7 +279,7 @@ class Garp_Auth_Adapter_PasswordlessTest extends Garp_Test_PHPUnit_TestCase {
 
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         if (!$this->_testsEnabled) {
             return;
         }

--- a/tests/library/Garp/Db/Table/RowTest.php
+++ b/tests/library/Garp/Db/Table/RowTest.php
@@ -27,7 +27,7 @@ class Garp_Db_Table_RowTest extends Garp_Test_PHPUnit_TestCase {
         $this->assertFalse($row->isConnected());
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
 
         $dbAdapter = $this->_getSqlite();
@@ -36,7 +36,7 @@ class Garp_Db_Table_RowTest extends Garp_Test_PHPUnit_TestCase {
         $dbAdapter->exec('CREATE TABLE foo (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, name VARCHAR, foo TEXT)');
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         parent::tearDown();
 
         $dbAdapter = Zend_Db_Table::getDefaultAdapter();

--- a/tests/library/Garp/File/Storage/LocalTest.php
+++ b/tests/library/Garp/File/Storage/LocalTest.php
@@ -27,7 +27,7 @@ class Garp_File_Storage_LocalTest extends Garp_Test_PHPUnit_TestCase {
         $this->assertEquals($testContent, $storedContents);
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(
@@ -47,7 +47,7 @@ class Garp_File_Storage_LocalTest extends Garp_Test_PHPUnit_TestCase {
         $this->_storage->setDocRoot(GARP_APPLICATION_PATH . '/../tests/');
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         $this->_storage->remove($this->_gzipTestFile);
     }
 

--- a/tests/library/Garp/FileTest.php
+++ b/tests/library/Garp/FileTest.php
@@ -128,7 +128,7 @@ class Garp_FileTest extends Garp_Test_PHPUnit_TestCase {
         return preg_match('/[^A-Za-z0-9_\.-]/', $filename) === 0;
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(

--- a/tests/library/Garp/Model/Behavior/HtmlFilterableTest.php
+++ b/tests/library/Garp/Model/Behavior/HtmlFilterableTest.php
@@ -14,7 +14,7 @@ class Garp_Model_Behavior_HtmlFilterableTest extends Garp_Test_PHPUnit_TestCase 
 
         $test = '<banana>This tag does not exist</banana>';
         $this->assertEquals('This tag does not exist', $filterable->filter(
-            $test, 
+            $test,
             $this->_getConfig()
         ));
     }
@@ -42,7 +42,7 @@ class Garp_Model_Behavior_HtmlFilterableTest extends Garp_Test_PHPUnit_TestCase 
         $this->assertEquals($test, $filterable->filter($test, $this->_getConfig()));
     }
 
-    
+
     /**
      * @test
      */
@@ -128,7 +128,7 @@ class Garp_Model_Behavior_HtmlFilterableTest extends Garp_Test_PHPUnit_TestCase 
      *
      * @return void
      */
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(
@@ -144,7 +144,7 @@ class Garp_Model_Behavior_HtmlFilterableTest extends Garp_Test_PHPUnit_TestCase 
     }
 
     /**
-     * Get default config for HTMLPurifier 
+     * Get default config for HTMLPurifier
      */
     protected function _getConfig() {
         $filterable = new Garp_Model_Behavior_HtmlFilterable(array());

--- a/tests/library/Garp/Model/Db/FakerTest.php
+++ b/tests/library/Garp/Model/Db/FakerTest.php
@@ -93,7 +93,7 @@ class Garp_Model_Db_FakerTest extends Garp_Test_PHPUnit_TestCase {
         );
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(

--- a/tests/library/Garp/Model/DbTest.php
+++ b/tests/library/Garp/Model/DbTest.php
@@ -53,7 +53,7 @@ class Garp_Model_DbTest extends Garp_Test_PHPUnit_TestCase {
         ];
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
 
         $dbAdapter = $this->_getSqlite();

--- a/tests/library/Garp/Service/Elasticsearch/ConfigurationTest.php
+++ b/tests/library/Garp/Service/Elasticsearch/ConfigurationTest.php
@@ -29,7 +29,7 @@ class Garp_Service_Elasticsearch_ConfigurationTest extends Garp_Test_PHPUnit_Tes
     }
 
 
-    public function setUp() {
+    public function setUp(): void {
         // only test ElasticSearch in a project that uses ElasticSearch
         if (!isset(Zend_Registry::get('config')->elasticsearch)) {
             return;

--- a/tests/library/Garp/Service/Elasticsearch/ModelTest.php
+++ b/tests/library/Garp/Service/Elasticsearch/ModelTest.php
@@ -23,7 +23,7 @@ class Garp_Service_Elasticsearch_ModelTest extends Garp_Test_PHPUnit_TestCase {
     protected $_model;
 
 
-    public function setUp() {
+    public function setUp(): void {
         $model = new Garp_Service_Elasticsearch_Model(self::BOGUS_MODEL_NAME);
         $this->setModel($model);
     }

--- a/tests/library/Garp/Service/Slack/ConfigTest.php
+++ b/tests/library/Garp/Service/Slack/ConfigTest.php
@@ -29,7 +29,7 @@ class Garp_Service_Slack_ConfigTest extends Garp_Test_PHPUnit_TestCase {
     }
 
 
-    public function setUp() {
+    public function setUp(): void {
         $mockConfig = array(
             'token' => 'GLKJKJHF234/234AKDJH/k234kjh324afa',
             'channel' => '#mychannel',

--- a/tests/library/Garp/Spawn/Model/SetTest.php
+++ b/tests/library/Garp/Spawn/Model/SetTest.php
@@ -18,7 +18,7 @@ class Garp_Spawn_Model_SetTest extends Garp_Test_PHPUnit_TestCase {
     protected $_modelSet;
 
 
-    public function setUp() {
+    public function setUp(): void {
         $this->_mocks['directory'] = GARP_APPLICATION_PATH . '/../tests/model-config/';
         $this->_modelSet = $this->_constructMockModelSet();
     }

--- a/tests/library/Garp/Spawn/ModelTest.php
+++ b/tests/library/Garp/Spawn/ModelTest.php
@@ -14,7 +14,7 @@ class Garp_Spawn_Model_BaseTest extends Garp_Test_PHPUnit_TestCase {
     );
 
 
-    public function setUp() {
+    public function setUp(): void {
         $this->_mocks['directory'] = GARP_APPLICATION_PATH . "/../tests/model-config/";
     }
 

--- a/tests/library/Garp/Spawn/MySql/TableTest.php
+++ b/tests/library/Garp/Spawn/MySql/TableTest.php
@@ -15,7 +15,7 @@ class Garp_Spawn_MySql_TableTest extends Garp_Test_PHPUnit_TestCase {
     );
 
 
-    public function setUp() {
+    public function setUp(): void {
         $this->_mocks['directory'] = GARP_APPLICATION_PATH . "/../tests/model-config/";
         $this->_mocks['sql'] = file_get_contents(
             GARP_APPLICATION_PATH . '/../tests/files/bogus.sql'

--- a/tests/library/Garp/Spawn/Relation/SetTest.php
+++ b/tests/library/Garp/Spawn/Relation/SetTest.php
@@ -18,7 +18,7 @@ class Garp_Spawn_Relation_SetTest extends Garp_Test_PHPUnit_TestCase {
     protected $_modelSet;
 
 
-    public function setUp() {
+    public function setUp(): void {
         $this->_mocks['directory'] = GARP_APPLICATION_PATH . "/../tests/model-config/";
         $this->_modelSet = $this->_constructMockModelSet();
     }

--- a/tests/library/Garp/Util/AssetUrlTest.php
+++ b/tests/library/Garp/Util/AssetUrlTest.php
@@ -8,7 +8,7 @@
  */
 class Garp_Util_AssetUrlTest extends Garp_Test_PHPUnit_TestCase {
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(

--- a/tests/library/Garp/Util/FullUrlTest.php
+++ b/tests/library/Garp/Util/FullUrlTest.php
@@ -6,7 +6,7 @@
  */
 class Garp_Util_FullUrlTest extends Garp_Test_PHPUnit_TestCase {
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         $this->_helper->injectConfigValues(
             array(

--- a/tests/library/Garp/VersionTest.php
+++ b/tests/library/Garp/VersionTest.php
@@ -26,13 +26,13 @@ class Garp_VersionTest extends Garp_Test_PHPUnit_TestCase {
         $this->assertEquals('v1.0.23-g4390291', $version->getVersion(), 'bustCache() clears the cache');
     }
 
-    public function setUp() {
+    public function setUp(): void {
         parent::setUp();
         file_put_contents($this->_getVersionLocation(), self::MOCK_VERSION);
         Garp_Version::bustCache();
     }
 
-    public function tearDown() {
+    public function tearDown(): void {
         unlink($this->_getVersionLocation());
     }
 


### PR DESCRIPTION
This allows you to start extending other TestCase classes (like the one
from Laravel), while simultaneously keeping Garp functionality.
This hopefully eases the transition to another framework.